### PR TITLE
Add Meson option to control tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ ninja -C builddir test
 
 Running the functional tests requires Python >= 3.11
 
+Meson currently is configured with support to build all of it's dependencies
+from source if they are not otherwise detected, by fetching at configure time.
+If this is not desirable, calling:
+
+```sh
+meson setup builddir --wrap-mode=nofallback
+```
+
+Will disable this behavior. This will require that all dependencies have been
+installed and are discoverable at configure time.
+
 ## Status
 
 CPS-config is currently in alpha status. Some things work, others do not.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ ninja -C builddir test
 
 Running the functional tests requires Python >= 3.11
 
-Meson currently is configured with support to build all of it's dependencies
-from source if they are not otherwise detected, by fetching at configure time.
+Meson currently is configured with support to build all of its dependencies
+from source if they are not otherwise detected by fetching them at configure time.
 If this is not desirable, calling:
 
 ```sh
@@ -26,6 +26,19 @@ meson setup builddir --wrap-mode=nofallback
 
 Will disable this behavior. This will require that all dependencies have been
 installed and are discoverable at configure time.
+
+Test execution can be controlled by setting the `test` option to Meson:
+```sh
+meson setup builddir -Dtests=disabled
+```
+Or, alternatively, to enable tests:
+```sh
+meson configure builddir -Dtests=enabled
+```
+This is a Meson [feature](https://mesonbuild.com/Build-options.html#features)
+option, which can have a state of `disabled`, `enabled`, or `auto`, as described
+in the linked documentation. The default is `auto`, which is usually desirable
+for end users.
 
 ## Status
 

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright © 2023-2024 Dylan Baker
+
 project(
   'cps-config',
   'cpp',

--- a/meson.build
+++ b/meson.build
@@ -32,16 +32,17 @@ cps_config = executable(
   install : true,
 )
 
+build_tests = get_option('tests')
 
 test(
   'pkg-config compatibility',
-  find_program('python', version : '>=3.11', required : false, disabler : true),
+  find_program('python', version : '>=3.11', required : build_tests, disabler : true),
   args: [files('tests/runner.py'), cps_config, 'tests/cases.toml'],
   protocol : 'tap',
   env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cases' },
 )
 
-dep_gtest = dependency('gtest_main', required : false, disabler : true, allow_fallback : true)
+dep_gtest = dependency('gtest_main', required : build_tests, disabler : true, allow_fallback : true)
 
 foreach t : ['version', 'utils']
   test(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright © 2024 Dylan Baker
+
+option(
+    'tests',
+    type : 'feature',
+    description : 'Build and run tests',
+)

--- a/src/cps/meson.build
+++ b/src/cps/meson.build
@@ -1,8 +1,8 @@
 
 conf = configuration_data()
 conf.set_quoted('CPS_VERSION', meson.project_version())
-foreach f : ['USE_BUILTIN_UNREACHABLE']
-  conf.set10('CPS_@0@'.format(f.to_upper()), cpp.has_function(f))
+foreach f : ['unreachable']
+  conf.set10('CPS_USE_BUILTIN_@0@'.format(f.to_upper()), cpp.has_function(f))
 endforeach
 
 conf_h = configure_file(

--- a/src/cps/meson.build
+++ b/src/cps/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright © 2023-2024 Dylan Baker
 
 conf = configuration_data()
 conf.set_quoted('CPS_VERSION', meson.project_version())

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright © 2023-2024 Dylan Baker
+
 subdir('cps')
 
 cps_include_dir = include_directories('.')


### PR DESCRIPTION
This makes use of Meson's feature option, which gives fine control to packagers on whether to require tests or not, but also gives  a comfortable defaults for average users.