### PR TITLE
Fix gtest dependency

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -34,7 +34,7 @@ jobs:
       - name: apt
         run: |
           sudo apt update
-          sudo apt install ccache clang libjsoncpp-dev libexpected-dev cmake googletest libfmt-dev ninja-build
+          sudo apt install ccache clang libjsoncpp-dev libexpected-dev cmake libgtest-dev libfmt-dev ninja-build
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
       - name: Setup ccache

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ test(
   env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cases' },
 )
 
-dep_gtest = dependency('gtest_main', required : false, disabler : true)
+dep_gtest = dependency('gtest_main', required : false, disabler : true, allow_fallback : true)
 
 foreach t : ['version', 'utils']
   test(


### PR DESCRIPTION
This has two fixes:
 1. it fixes the CI to install the gtest development files
 2. it fixes the Meson build to allow gtest to fall back to a wrap