### PR TITLE
Fix interaction between requirements with versions and packages without them

### DIFF
--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -213,9 +213,17 @@ namespace cps::search {
                 // The conditions it could fail to meet are:
                 //  1. the provided version (or Compat-Version) is < the required version
                 //  2. This package lacks required components
-                if (p.version && requirements.version) {
-                    if (version::compare(p.version.value_or("0"), version::Operator::lt,
-                                         requirements.version.value_or("0"), p.version_schema)) {
+                if (requirements.version) {
+                    // From the CPS spec, version 0.10.0, for package::version,
+                    // which as the same semantics as requirement::version:
+                    //
+                    // > If not provided, the CPS will not satisfy any request for
+                    // > a specific version of the package.
+                    if (!p.version) {
+                        continue;
+                    }
+                    if (version::compare(p.version.value(), version::Operator::lt, requirements.version.value(),
+                                         p.version_schema)) {
                         continue;
                     }
                 }

--- a/tests/cases.toml
+++ b/tests/cases.toml
@@ -87,3 +87,10 @@
   cps = "diamond"
   args = ["--cflags-only-I"]
   expected = "-I/something -I/opt/include"
+
+[[case]]
+  name = "Requires version, but version not set"
+  cps = "needs-version.cps"
+  args = ["--modversion", "--print-errors", "--errors-to-stdout"]
+  expected = "Could not find a CPS file for needs-version.cps"
+  returncode = 1

--- a/tests/cases/lib/cps/needs-version.cps
+++ b/tests/cases/lib/cps/needs-version.cps
@@ -1,0 +1,17 @@
+{
+    "name": "needs-components1",
+    "cps_version": "0.10.0",
+    "requires": {
+        "multiple-components": {
+            "components": ["sample3"],
+            "version": "1.0"
+        }
+    },
+    "components": {
+        "default": {
+            "type": "interface",
+            "requires": ["multiple-components:sample3"]
+        }
+    },
+    "default_components": ["default"]
+}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
         args: list[str]
         expected: str
         mode: typing.NotRequired[typing.Literal['pkgconf']]
+        returncode: typing.NotRequired[int]
 
     class TestDescription(typing.TypedDict):
 
@@ -76,7 +77,7 @@ async def test(runner: str, case_: TestCase) -> Result:
         out = bout.decode().strip()
         err = berr.decode().strip()
 
-        success = proc.returncode == 0 and out == expected
+        success = proc.returncode == case_.get('returncode', 0) and out == expected
         result = Status.PASS if success else Status.FAIL
         returncode = proc.returncode
     except asyncio.TimeoutError:


### PR DESCRIPTION
If a Package "Alpha" requires a package "Beta", and the CPS file A for Alpha has a version requirement, and CPS file B for Beta does not set a version, then it is does not fulfill the requirement of A for Beta.