### PR TITLE
gitignore: fix .wrap files accidentally ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-subprojects/
+subprojects/*
 !subprojects/*.wrap


### PR DESCRIPTION
`subprojects/` apparently led the entire folder to be ignored. That way `!subprojects/*.wrap` does not have the intended effect.