### PR TITLE
meson: enforce python must be >= 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ meson setup builddir
 ninja -C builddir test
 ```
 
+Running the functional tests requires Python >= 3.11
+
 ## Status
 
 CPS-config is currently in alpha status. Some things work, others do not.

--- a/meson.build
+++ b/meson.build
@@ -51,10 +51,11 @@ cps_config = executable(
   install : true,
 )
 
+
 test(
   'pkg-config compatibility',
-  find_program('tests/runner.py', required : false, disabler : true),
-  args: [cps_config, 'tests/cases.toml'],
+  find_program('python', version : '>=3.11', required : false, disabler : true),
+  args: [files('tests/runner.py'), cps_config, 'tests/cases.toml'],
   protocol : 'tap',
   env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cases' },
 )

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
         case: list[TestCase]
 
 
-SOURCE_DIR = os.path.dirname(os.path.dirname(__file__))
+SOURCE_DIR = os.path.normpath(os.path.dirname(os.path.dirname(__file__)))
 PREFIX = os.path.join(SOURCE_DIR, 'tests/cases')
 _PRINT_LOCK = asyncio.Lock()
 


### PR DESCRIPTION
Since we require both `tomllib` and the `asyncio.timeout` function. We could lower the requirement if and/or when that becomes necessary.