### PR TITLE
Update cases to us 0.10 format instead of 0.9 format

### DIFF
--- a/src/cps/loader.cpp
+++ b/src/cps/loader.cpp
@@ -114,10 +114,10 @@ namespace cps::loader {
             if (value.isObject()) {
                 // TODO: simplify this further, maybe with a loop?
                 auto && cb = [](auto && r) { return r.value_or(std::vector<std::string>{}); };
-                ret[KnownLanguages::c] = CPS_TRY(get_optional<std::vector<std::string>>(value, name, "C").map(cb));
-                ret[KnownLanguages::cxx] = CPS_TRY(get_optional<std::vector<std::string>>(value, name, "C++").map(cb));
+                ret[KnownLanguages::c] = CPS_TRY(get_optional<std::vector<std::string>>(value, name, "c").map(cb));
+                ret[KnownLanguages::cxx] = CPS_TRY(get_optional<std::vector<std::string>>(value, name, "c++").map(cb));
                 ret[KnownLanguages::fortran] =
-                    CPS_TRY(get_optional<std::vector<std::string>>(value, name, "Fortran").map(cb));
+                    CPS_TRY(get_optional<std::vector<std::string>>(value, name, "fortran").map(cb));
             } else if (value.isArray()) {
                 std::vector<std::string> fin;
                 for (auto && v : value) {
@@ -172,9 +172,9 @@ namespace cps::loader {
                 const Json::Value obj = *itr;
 
                 ret.emplace(key, Requirement{
-                                     CPS_TRY(get_optional<std::vector<std::string>>(require, name, "Components"))
+                                     CPS_TRY(get_optional<std::vector<std::string>>(require, name, "components"))
                                          .value_or(std::vector<std::string>{}),
-                                     CPS_TRY(get_optional<std::string>(require, name, "Version")),
+                                     CPS_TRY(get_optional<std::string>(require, name, "version")),
                                  });
             }
 
@@ -211,16 +211,16 @@ namespace cps::loader {
                 }
 
                 components[key] = Component{
-                    CPS_TRY(get_required<std::string>(comp, name, "Type").map(string_to_type)),
-                    CPS_TRY(get_lang_values(comp, name, "Compile-Flags")),
-                    CPS_TRY(get_lang_values(comp, name, "Includes")), CPS_TRY(get_defines(comp, name, "Defines")),
-                    CPS_TRY(get_optional<std::vector<std::string>>(comp, name, "Link-Libraries"))
+                    CPS_TRY(get_required<std::string>(comp, name, "type").map(string_to_type)),
+                    CPS_TRY(get_lang_values(comp, name, "compile_flags")),
+                    CPS_TRY(get_lang_values(comp, name, "includes")), CPS_TRY(get_defines(comp, name, "defines")),
+                    CPS_TRY(get_optional<std::vector<std::string>>(comp, name, "link_libraries"))
                         .value_or(std::vector<std::string>{}),
                     // TODO: this is required if the type != interface
-                    CPS_TRY(get_optional<std::string>(comp, name, "Location")),
+                    CPS_TRY(get_optional<std::string>(comp, name, "location")),
                     // XXX: https://github.com/cps-org/cps/issues/34
-                    CPS_TRY(get_optional<std::string>(comp, name, "Link-Location")),
-                    CPS_TRY(get_optional<std::vector<std::string>>(comp, name, "Requires"))
+                    CPS_TRY(get_optional<std::string>(comp, name, "link_location")),
+                    CPS_TRY(get_optional<std::vector<std::string>>(comp, name, "requires"))
                         .value_or(std::vector<std::string>{})};
             }
 
@@ -276,14 +276,14 @@ namespace cps::loader {
         file >> root;
 
         return Package{
-            CPS_TRY(get_required<std::string>(root, "package", "Name")),
-            CPS_TRY(get_required<std::string>(root, "package", "Cps-Version")),
-            CPS_TRY(get_components(root, "package", "Components")),
-            CPS_TRY(get_optional<std::string>(root, "package", "Cps-Path")).value_or(path.parent_path()),
-            CPS_TRY(get_optional<std::vector<std::string>>(root, "package", "Default-Components")),
-            CPS_TRY(get_requires(root, "package", "Requires")),
-            CPS_TRY(get_optional<std::string>(root, "package", "Version")),
-            CPS_TRY(get_optional<std::string>(root, "package", "Version-Schema").map([](auto && v) {
+            CPS_TRY(get_required<std::string>(root, "package", "name")),
+            CPS_TRY(get_required<std::string>(root, "package", "cps_version")),
+            CPS_TRY(get_components(root, "package", "components")),
+            CPS_TRY(get_optional<std::string>(root, "package", "cps_path")).value_or(path.parent_path()),
+            CPS_TRY(get_optional<std::vector<std::string>>(root, "package", "default_components")),
+            CPS_TRY(get_requires(root, "package", "requires")),
+            CPS_TRY(get_optional<std::string>(root, "package", "version")),
+            CPS_TRY(get_optional<std::string>(root, "package", "version_schema").map([](auto && v) {
                 return string_to_schema(v.value_or("simple"));
             })),
         };

--- a/tests/cases/lib/cps/cps-path-not-set.cps
+++ b/tests/cases/lib/cps/cps-path-not-set.cps
@@ -1,14 +1,19 @@
 {
-    "Name": "cps-path-not-set",
-    "Cps-Version": "0.9.0",
-    "Version": "1.0.0",
-    "Components": {
+    "name": "cps-path-not-set",
+    "cps_version": "0.10.0",
+    "version": "1.0.0",
+    "components": {
         "default": {
-            "Type": "archive",
-            "Includes": {"C": ["@prefix@/err"]},
-            "Location": "@prefix@/lib/libfoo.a"
+            "type": "archive",
+            "includes": {
+                "c": [
+                    "@prefix@/err"
+                ]
+            },
+            "location": "@prefix@/lib/libfoo.a"
         }
     },
-    "Default-Components": ["default"]
+    "default_components": [
+        "default"
+    ]
 }
-

--- a/tests/cases/lib/cps/cps-path-set.cps
+++ b/tests/cases/lib/cps/cps-path-set.cps
@@ -1,15 +1,20 @@
 {
-    "Name": "cps-path-set",
-    "Cps-Version": "0.9.0",
-    "Cps-Path": "/sentinel/lib/cps/",
-    "Version": "1.0.0",
-    "Components": {
+    "name": "cps-path-set",
+    "cps_version": "0.10.0",
+    "cps_path": "/sentinel/lib/cps/",
+    "version": "1.0.0",
+    "components": {
         "default": {
-            "Type": "archive",
-            "Includes": {"C": ["@prefix@/err"]},
-            "Location": "@prefix@/lib/libfoo.a"
+            "type": "archive",
+            "includes": {
+                "c": [
+                    "@prefix@/err"
+                ]
+            },
+            "location": "@prefix@/lib/libfoo.a"
         }
     },
-    "Default-Components": ["default"]
+    "default_components": [
+        "default"
+    ]
 }
-

--- a/tests/cases/lib/cps/diamond.cps
+++ b/tests/cases/lib/cps/diamond.cps
@@ -1,18 +1,20 @@
 {
-    "Name": "diamond",
-    "Cps-Version": "0.9.0",
-    "Requires": {
+    "name": "diamond",
+    "cps_version": "0.10.0",
+    "requires": {
         "needs-components1": {},
         "needs-components2": {}
     },
-    "Components": {
+    "components": {
         "default": {
-            "Type": "interface",
-            "Requires": ["needs-components1", "needs-components2"]
+            "type": "interface",
+            "requires": [
+                "needs-components1",
+                "needs-components2"
+            ]
         }
     },
-    "Default-Components": ["default"]
+    "default_components": [
+        "default"
+    ]
 }
-
-
-

--- a/tests/cases/lib/cps/minimal.cps
+++ b/tests/cases/lib/cps/minimal.cps
@@ -1,22 +1,51 @@
 {
-    "Name": "minimal",
-    "Cps-Version": "0.9.0",
-    "Version": "1.0.0",
-    "Components": {
+    "name": "minimal",
+    "cps_version": "0.10.0",
+    "version": "1.0.0",
+    "components": {
         "sample0": {
-            "Type": "archive",
-            "Compile-Flags": ["-fsentinal"],
-            "Includes": {"C": ["/err"]},
-            "Defines": {"C": ["-DFAIL"]},
-            "Location": "fake"
+            "type": "archive",
+            "compile_flags": [
+                "-fsentinal"
+            ],
+            "includes": {
+                "c": [
+                    "/err"
+                ]
+            },
+            "defines": {
+                "c": [
+                    "-DFAIL"
+                ]
+            },
+            "location": "fake"
         },
         "sample1": {
-            "Type": "archive",
-            "Compile-Flags": ["-fopenmp"],
-            "Includes": {"C": ["/usr/local/include", "/opt/include"]},
-            "Defines": {"C": ["FOO=1", "BAR=2", "!BAR", "OTHER"], "C++": ["!FOO"]},
-            "Location": "fake"
+            "type": "archive",
+            "compile_flags": [
+                "-fopenmp"
+            ],
+            "includes": {
+                "c": [
+                    "/usr/local/include",
+                    "/opt/include"
+                ]
+            },
+            "defines": {
+                "c": [
+                    "FOO=1",
+                    "BAR=2",
+                    "!BAR",
+                    "OTHER"
+                ],
+                "c++": [
+                    "!FOO"
+                ]
+            },
+            "location": "fake"
         }
     },
-    "Default-Components": ["sample1"]
+    "default_components": [
+        "sample1"
+    ]
 }

--- a/tests/cases/lib/cps/multiple-components.cps
+++ b/tests/cases/lib/cps/multiple-components.cps
@@ -1,40 +1,70 @@
 {
-    "Name": "multiple-components",
-    "Cps-Version": "0.9.0",
-    "Requires": {
+    "name": "multiple-components",
+    "cps_version": "0.10.0",
+    "requires": {
         "minimal": {}
     },
-    "Components": {
+    "components": {
         "sample1": {
-            "Type": "archive",
-            "Compile-Flags": ["-fopenmp"],
-            "Includes": {"C": ["/usr/local/include"]},
-            "Defines": [],
-            "Location": "fake"
+            "type": "archive",
+            "compile_flags": [
+                "-fopenmp"
+            ],
+            "includes": {
+                "c": [
+                    "/usr/local/include"
+                ]
+            },
+            "defines": [],
+            "location": "fake"
         },
         "sample2": {
-            "Type": "archive",
-            "Compile-Flags": ["-fopenmp"],
-            "Includes": ["/opt/include"],
-            "Defines": {"C": ["FOO=1"], "C++": ["!FOO"]},
-            "Location": "/something/lib/libfoo.so.1.2.0"
+            "type": "archive",
+            "compile_flags": [
+                "-fopenmp"
+            ],
+            "includes": [
+                "/opt/include"
+            ],
+            "defines": {
+                "c": [
+                    "FOO=1"
+                ],
+                "c++": [
+                    "!FOO"
+                ]
+            },
+            "location": "/something/lib/libfoo.so.1.2.0"
         },
         "sample3": {
-            "Type": "archive",
-            "Includes": {"C": ["/something"]},
-            "Link-Libraries": ["dl", "rt"],
-            "Location": "/something/lib/libfoo.so.1.2.0",
-            "Link-Location": "/something/lib/libfoo.so"
+            "type": "archive",
+            "includes": {
+                "c": [
+                    "/something"
+                ]
+            },
+            "link_libraries": [
+                "dl",
+                "rt"
+            ],
+            "location": "/something/lib/libfoo.so.1.2.0",
+            "link_location": "/something/lib/libfoo.so"
         },
         "sample4": {
-            "Type": "interface",
-            "Requires": [":sample3"]
+            "type": "interface",
+            "requires": [
+                ":sample3"
+            ]
         },
         "requires-external": {
-            "Type": "interface",
-            "Requires": ["minimal:sample0"]
+            "type": "interface",
+            "requires": [
+                "minimal:sample0"
+            ]
         }
     },
-    "Default-Components": ["sample1", "sample2"]
+    "default_components": [
+        "sample1",
+        "sample2"
+    ]
 }
-

--- a/tests/cases/lib/cps/needs-components1.cps
+++ b/tests/cases/lib/cps/needs-components1.cps
@@ -1,18 +1,22 @@
 {
-    "Name": "needs-components1",
-    "Cps-Version": "0.9.0",
-    "Requires": {
+    "name": "needs-components1",
+    "cps_version": "0.10.0",
+    "requires": {
         "multiple-components": {
-            "components": ["sample3"]
+            "components": [
+                "sample3"
+            ]
         }
     },
-    "Components": {
+    "components": {
         "default": {
-            "Type": "interface",
-            "Requires": ["multiple-components:sample3"]
+            "type": "interface",
+            "requires": [
+                "multiple-components:sample3"
+            ]
         }
     },
-    "Default-Components": ["default"]
+    "default_components": [
+        "default"
+    ]
 }
-
-

--- a/tests/cases/lib/cps/needs-components2.cps
+++ b/tests/cases/lib/cps/needs-components2.cps
@@ -1,18 +1,22 @@
 {
-    "Name": "needs-components2",
-    "Cps-Version": "0.9.0",
-    "Requires": {
+    "name": "needs-components2",
+    "cps_version": "0.10.0",
+    "requires": {
         "multiple-components": {
-            "components": ["sample2"]
+            "components": [
+                "sample2"
+            ]
         }
     },
-    "Components": {
+    "components": {
         "default": {
-            "Type": "interface",
-            "Requires": ["multiple-components:sample2"]
+            "type": "interface",
+            "requires": [
+                "multiple-components:sample2"
+            ]
         }
     },
-    "Default-Components": ["default"]
+    "default_components": [
+        "default"
+    ]
 }
-
-


### PR DESCRIPTION
This changes the keys from `Proper-Case` -> `proper_case`.

I've sent this as two commits despite the fact that it's one logical change because the first commit is largely machine generated (with manual touch ups), while the second is human generated. Since the script used for the conversion is in the commit message for the first patch, this seems like a good case for a merge, despite the fact that I normally dislike merges.

Fixes #11