### PR TITLE
Struct for enviroment variables

### DIFF
--- a/src/cps-config/main.cpp
+++ b/src/cps-config/main.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cps/config.hpp"
+#include "cps/env.hpp"
 #include "cps/printer.hpp"
 #include "cps/search.hpp"
 
@@ -30,6 +31,9 @@ namespace cps_config {
         std::string format{"pkgconf"};
         std::string package_name;
         bool errors_to_stdout = false;
+
+        // read enviroment variables
+        auto env = cps::get_env();
 
         static auto const description = R"(cps-config is a utility for querying and using installed libraries.
 
@@ -77,7 +81,7 @@ Support:
             fmt::print("{}\n", CPS_VERSION);
             return ProgramOutput::Success();
         }
-        if (parsed_options.count("print-errors")) {
+        if (parsed_options.count("print-errors") || env.debug_spew) {
             conf.print_errors = true;
         }
         if (parsed_options.count("errors-to-stdout")) {
@@ -128,7 +132,7 @@ Support:
             format = parsed_options["format"].as<std::string>();
         }
 
-        auto && p = cps::search::find_package(package_name, components, components.empty());
+        auto && p = cps::search::find_package(package_name, components, components.empty(), env);
         if (!p) {
             return ProgramOutput{.retval = 1,
                                  .debug_output = conf.print_errors ? fmt::format("{}\n", p.error()) : "",

--- a/src/cps/env.cpp
+++ b/src/cps/env.cpp
@@ -1,0 +1,23 @@
+// Copyright © 2023-2024 Dylan Baker
+// Copyright © 2024 Tyler Weaver
+// SPDX-License-Identifier: MIT
+
+#include "cps/env.hpp"
+
+#include <cstdlib>
+#include <string>
+
+namespace cps {
+
+    Env get_env() {
+        auto env = Env{};
+        if (const char * env_c = std::getenv("CPS_PATH")) {
+            env.cps_path = std::string(env_c);
+        }
+        if (std::getenv("PKG_CONFIG_DEBUG_SPEW") || std::getenv("CPS_CONFIG_DEBUG_SPEW")) {
+            env.debug_spew = true;
+        }
+        return env;
+    }
+
+} // namespace cps

--- a/src/cps/env.hpp
+++ b/src/cps/env.hpp
@@ -1,0 +1,19 @@
+// Copyright © 2023-2024 Dylan Baker
+// Copyright © 2024 Tyler Weaver
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace cps {
+
+    struct Env {
+        std::optional<std::string> cps_path = std::nullopt;
+        bool debug_spew = false;
+    };
+
+    Env get_env();
+
+} // namespace cps

--- a/src/cps/search.hpp
+++ b/src/cps/search.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "cps/env.hpp"
 #include "cps/loader.hpp"
 
 #include <tl/expected.hpp>
@@ -27,9 +28,9 @@ namespace cps::search {
     // TODO: restrictions like versions
     // TODO: caching loading packages?
     // TODO: multiple versions of packages?
-    tl::expected<Result, std::string> find_package(std::string_view name);
+    tl::expected<Result, std::string> find_package(std::string_view name, Env env);
 
     tl::expected<Result, std::string> find_package(std::string_view name, const std::vector<std::string> & components,
-                                                   bool default_components);
+                                                   bool default_components, Env env);
 
 } // namespace cps::search

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ cps_include_dir = include_directories('.')
 
 libcps = static_library(
   'cps',
+  'cps/env.cpp',
   'cps/loader.cpp',
   'cps/printer.cpp',
   'cps/search.cpp',


### PR DESCRIPTION
Based on
- #59

Please review only the final commit. Here is my attempt to inject environment variables into the library functions without making them depend on the system's state. This could make testing easier in cases where we want to test the behavior when setting specific environment variables; it also puts all the reading of environment variables into one function.