### PR TITLE
Ignore clangd cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 subprojects/*
 !subprojects/*.wrap
 .pixi/
+.cache/


### PR DESCRIPTION
Here is a tiny one. I turned on clangd, and it makes a .cache directory. Would you mind if we ignore this in git?
