### PR TITLE
Improve help features

### DIFF
--- a/src/cps-config/main.cpp
+++ b/src/cps-config/main.cpp
@@ -8,6 +8,7 @@
 #include "cps/search.hpp"
 
 #include <cxxopts.hpp>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <optional>
@@ -37,6 +38,12 @@ namespace cps_config {
         auto env = cps::get_env();
 
         static auto const description = R"(cps-config is a utility for querying and using installed libraries.
+
+Envionment Variables:
+   CPS_PATH               search path for directories with CPS files;
+                          see the CPS specification for more details
+   CPS_CONFIG_DEBUG_SPEW  same as --print-errors
+   PKG_CONFIG_DEBUG_SPEW  same as --print-errors
 
 Examples:
 
@@ -73,7 +80,13 @@ Support:
         // clang-format on
         options.parse_positional({"package"});
         options.positional_help("<packages>");
-        auto parsed_options = options.parse(argc, argv);
+        cxxopts::ParseResult parsed_options;
+        try {
+            parsed_options = options.parse(argc, argv);
+        } catch (cxxopts::option_not_exists_exception & exception) {
+            auto const debug_output = fmt::format("Error -- {}.\n\n{}\n", exception.what(), options.help());
+            return ProgramOutput{.retval = 1, .debug_output = debug_output};
+        }
 
         if (parsed_options.count("help")) {
             fmt::print("{}\n", options.help());

--- a/src/cps/env.cpp
+++ b/src/cps/env.cpp
@@ -10,6 +10,8 @@
 namespace cps {
 
     Env get_env() {
+        // NOTE: When adding new environment variables, be sure to update the --help
+        //       message with documentation about the new feature.
         auto env = Env{};
         if (const char * env_c = std::getenv("CPS_PATH")) {
             env.cps_path = std::string(env_c);

--- a/subprojects/cxxopts.wrap
+++ b/subprojects/cxxopts.wrap
@@ -1,13 +1,12 @@
 [wrap-file]
-directory = cxxopts-3.1.1
-source_url = https://github.com/jarro2783/cxxopts/archive/v3.1.1.tar.gz
-source_filename = cxxopts-3.1.1.tar.gz
-source_hash = 523175f792eb0ff04f9e653c90746c12655f10cb70f1d5e6d6d9491420298a08
-patch_filename = cxxopts_3.1.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/cxxopts_3.1.1-1/get_patch
-patch_hash = 3a38f72d4a9c394d32db47bbca6f00cb6ee330434b82b653f9d04bdea73170bb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cxxopts_3.1.1-1/cxxopts-3.1.1.tar.gz
-wrapdb_version = 3.1.1-1
+directory = cxxopts-3.0.0
+source_url = https://github.com/jarro2783/cxxopts/archive/v3.0.0.tar.gz
+source_filename = cxxopts-3.0.0.tar.gz
+source_hash = 36f41fa2a46b3c1466613b63f3fa73dc24d912bc90d667147f1e43215a8c6d00
+patch_filename = cxxopts_3.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/cxxopts_3.0.0-1/get_patch
+patch_hash = 704d7f49f768dde81376a607e9a189bb7e7f151bfc5512d9b7af9e13df2024cb
 
 [provide]
 cxxopts = cxxopts_dep
+

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,13 +1,12 @@
 [wrap-file]
-directory = fmt-10.1.1
-source_url = https://github.com/fmtlib/fmt/archive/10.1.1.tar.gz
-source_filename = fmt-10.1.1.tar.gz
-source_hash = 78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
-patch_filename = fmt_10.1.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/fmt_10.1.1-1/get_patch
-patch_hash = adec33acaf87c0859c52b242a44bc71c3427751da3f1adaed511f4186794a42f
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_10.1.1-1/fmt-10.1.1.tar.gz
-wrapdb_version = 10.1.1-1
+directory = fmt-8.1.1
+source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
+source_filename = fmt-8.1.1.tar.gz
+source_hash = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
+patch_filename = fmt_8.1.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_8.1.1-2/get_patch
+patch_hash = cd001046281330a8862591780a9ea71a1fa594edd0d015deb24e44680c9ea33b
+wrapdb_version = 8.1.1-2
 
 [provide]
 fmt = fmt_dep

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,16 +1,15 @@
 [wrap-file]
-directory = googletest-1.14.0
-source_url = https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-source_filename = gtest-1.14.0.tar.gz
-source_hash = 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
-patch_filename = gtest_1.14.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.14.0-1/get_patch
-patch_hash = 2e693c7d3f9370a7aa6dac802bada0874d3198ad4cfdf75647b818f691182b50
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.14.0-1/gtest-1.14.0.tar.gz
-wrapdb_version = 1.14.0-1
+directory = googletest-release-1.11.0
+source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
+source_filename = gtest-1.11.0.tar.gz
+source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
+patch_filename = gtest_1.11.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.11.0-2/get_patch
+patch_hash = 764530d812ac161c9eab02a8cfaec67c871fcfc5548e29fd3d488070913d4e94
 
 [provide]
 gtest = gtest_dep
 gtest_main = gtest_main_dep
 gmock = gmock_dep
 gmock_main = gmock_main_dep
+

--- a/subprojects/jsoncpp.wrap
+++ b/subprojects/jsoncpp.wrap
@@ -6,3 +6,4 @@ source_hash = f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
 
 [provide]
 jsoncpp = jsoncpp_dep
+

--- a/subprojects/tl-expected.wrap
+++ b/subprojects/tl-expected.wrap
@@ -1,13 +1,12 @@
 [wrap-file]
-directory = expected-1.1.0
-source_url = https://github.com/TartanLlama/expected/archive/v1.1.0.tar.gz
-source_filename = expected-1.1.0.tar.gz
-source_hash = 1db357f46dd2b24447156aaf970c4c40a793ef12a8a9c2ad9e096d9801368df6
-patch_filename = tl-expected_1.1.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/tl-expected_1.1.0-1/get_patch
-patch_hash = 8b1aa60a1ddd604494628f0c6b0ed569b9e1e2dc17dfdc09d5de5563ae8adfe3
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/tl-expected_1.1.0-1/expected-1.1.0.tar.gz
-wrapdb_version = 1.1.0-1
+directory = expected-1.0.0
+source_url = https://github.com/TartanLlama/expected/archive/v1.0.0.tar.gz
+source_filename = expected-1.0.0.tar.gz
+source_hash = 8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee
+patch_filename = tl-expected_1.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/tl-expected_1.0.0-1/get_patch
+patch_hash = 8b421837c67357a22bf105213c459786df0fe35a3bc8dc28b7fe9c44c7da71e3
 
 [provide]
 tl-expected = tl_expected_dep
+

--- a/tests/docker/rockylinux.Dockerfile
+++ b/tests/docker/rockylinux.Dockerfile
@@ -37,5 +37,9 @@ ARG setup_options=
 # Build cps-config and tests
 ENV CC="ccache $cc" CXX="ccache $cxx"
 ENV CCACHE_DIR=/ccache
-RUN meson setup builddir $setup_options
+# See https://github.com/cps-org/cps-config/issues/76
+# The versions of the cxxopts dependency are not compatible across
+# Ubuntu 22.04 and Rocky Linux. We will force building dependencies
+# from source via meson wraps on Rocky Linux for now.
+RUN meson setup builddir --wrap-mode=forcefallback $setup_options
 RUN --mount=type=cache,target=/ccache/ ninja -C builddir


### PR DESCRIPTION
* Provide a cleaner error and print the usage message when an invalid command-line argument is provided.
* Add environment variables to the usage message.

Ideally the documentation for the environment variables would go after the documentation for the CLI arguments, but cxxopts doesn't seem to have a mechanism for that arrangement.