### PR TITLE
Unordered compare diamond nodes

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -62,19 +62,9 @@ def unordered_compare(out, expected):
     if out == expected:
         return True
 
-    sorted_out = out.split()
-    sorted_expected = expected.split()
-    sorted_out.sort()
-    sorted_expected.sort()
-
-    if len(sorted_out) != len(sorted_expected):
-        return False
-
-    for i in range(len(sorted_out)):
-        if sorted_out[i] != sorted_expected[i]:
-            return False
-
-    return True
+    out_parts = out.split()
+    expected_parts = expected.split()
+    return sorted(out_parts) == sorted(expected_parts)
 
 async def test(runner: str, case_: TestCase) -> Result:
     cmd = [runner, case_['cps']] + case_['args']
@@ -94,7 +84,6 @@ async def test(runner: str, case_: TestCase) -> Result:
         out = bout.decode().strip()
         err = berr.decode().strip()
 
-        # success = proc.returncode == case_.get('returncode', 0) and out == expected
         success = proc.returncode == case_.get('returncode', 0) and unordered_compare(out, expected)
         result = Status.PASS if success else Status.FAIL
         returncode = proc.returncode

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -58,6 +58,23 @@ class Result:
     expected: str
     command: list[str]
 
+def unordered_compare(out, expected):
+    if out == expected:
+        return True
+
+    sorted_out = out.split()
+    sorted_expected = expected.split()
+    sorted_out.sort()
+    sorted_expected.sort()
+
+    if len(sorted_out) != len(sorted_expected):
+        return False
+
+    for i in range(len(sorted_out)):
+        if sorted_out[i] != sorted_expected[i]:
+            return False
+
+    return True
 
 async def test(runner: str, case_: TestCase) -> Result:
     cmd = [runner, case_['cps']] + case_['args']
@@ -77,7 +94,8 @@ async def test(runner: str, case_: TestCase) -> Result:
         out = bout.decode().strip()
         err = berr.decode().strip()
 
-        success = proc.returncode == case_.get('returncode', 0) and out == expected
+        # success = proc.returncode == case_.get('returncode', 0) and out == expected
+        success = proc.returncode == case_.get('returncode', 0) and unordered_compare(out, expected)
         result = Status.PASS if success else Status.FAIL
         returncode = proc.returncode
     except asyncio.TimeoutError:


### PR DESCRIPTION
As described in https://github.com/cps-org/cps-config/issues/80, for diamond chain there is no guarantee for the order of topological same-level nodes.

As the test case `component diamond`, it may fail in some platforms, such as MacOS.

This PR fix the fail by comparing nodes without considering their order.

Before:

![Screenshot 2024-05-03 at 09 33 02](https://github.com/cps-org/cps-config/assets/122971314/8fc0067e-cb46-438f-81f1-416ac45eba99)

After:

![Screenshot 2024-05-03 at 09 32 27](https://github.com/cps-org/cps-config/assets/122971314/a7246848-5352-422c-bc0f-9d0766183cc7)
