### PR TITLE
Add CMake as a supported build system

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -189,3 +189,6 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
+---
+Language: Json
+BasedOnStyle: LLVM

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ insert_final_newline = true
 [meson.build]
 indent_size = 2
 
-[CMakeLists.txt]
+[{CMakeLists.txt,*.cmake}]
 indent_size = 2
 
 [*.{toml,yml,json}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ insert_final_newline = true
 [meson.build]
 indent_size = 2
 
+[CMakeLists.txt]
+indent_size = 2
+
 [*.{toml,yml,json}]
 indent_size = 2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,7 @@ on:
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".github/workflows/cmake.yml"
+      - "VERSION"
   pull_request:
     branches: [main]
     paths:
@@ -17,6 +18,7 @@ on:
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".github/workflows/cmake.yml"
+      - "VERSION"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,84 @@
+name: CMake Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".github/workflows/cmake.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".github/workflows/cmake.yml"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cfg:
+          - {
+              id: ubuntu-gcc,
+              platform: ubuntu,
+              preset: default,
+            }
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build docker container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ matrix.cfg.id }}
+          file: tests/docker/${{ matrix.cfg.platform }}.Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Restore Compiler Cache
+        id: ccache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          # This ensures that every run saves cache even on cache hit
+          key: ${{ matrix.cfg.id }}-ccache-cmake-${{ github.run_id }}
+          restore-keys: |
+            ${{ matrix.cfg.id }}-ccache
+      - name: Start Docker Container
+        run: |
+          mkdir -p ${{ github.workspace }}/ccache
+          docker run -d --name ${{ matrix.cfg.id }} \
+          --mount=type=bind,source=${{ github.workspace }}/ccache,target=/ccache \
+          --mount=type=bind,source=${{ github.workspace }},target=/workdir \
+          ${{ matrix.cfg.id }} sleep infinity
+      - name: Build cps-config
+        run: |
+          docker exec \
+          -e CCACHE_DIR="/ccache" \
+          ${{ matrix.cfg.id }} \
+          bash -c "cmake -S /workdir -B /build/ --preset ${{ matrix.cfg.preset }} && \
+          cmake --build build --config RelWithDebInfo"
+      - name: Run Tests
+        run: |
+          docker exec ${{ matrix.cfg.id }} ctest --test-dir /build --output-on-failure -C RelWithDebInfo
+      - name: Stop Docker Container
+        run: |
+          docker stop ${{ matrix.cfg.id }}
+      - name: Save Cache
+        id: ccache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ matrix.cfg.id }}-ccache-${{ github.run_id }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,11 +29,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {
-              id: ubuntu-gcc,
-              platform: ubuntu,
-              preset: default,
-            }
+          - { id: ubuntu-gcc, platform: ubuntu, preset: default }
+          - { id: ubuntu-gcc-fetch, platform: ubuntu, preset: fetch-deps }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - ".github/workflows/test.yml"
       - "VERSION"
@@ -11,7 +11,7 @@ on:
       - "src/**"
       - "tests/**"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - ".github/workflows/test.yml"
       - "VERSION"
@@ -29,10 +29,34 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { id: ubuntu-gcc, platform: ubuntu, cc: gcc, cpp: g++, setup_options: "-Db_sanitize=address,undefined -Dunity=on -Dunity_size=12"}
-          - { id: ubuntu-clang, platform: ubuntu, cc: clang, cpp: clang++, setup_options: "-Dunity=on -Dunity_size=12"}
-          - { id: rockylinux-gcc, platform: rockylinux, cc: gcc, cpp: g++, setup_options: "-Dunity=on -Dunity_size=12"}
-          - { id: rockylinux-clang, platform: rockylinux, cc: clang, cpp: clang++, setup_options: "-Db_sanitize=address,undefined -Db_lundef=false -Dunity=on -Dunity_size=12"}
+          - {
+              id: ubuntu-gcc,
+              platform: ubuntu,
+              cc: gcc,
+              cpp: g++,
+              setup_options: "-Db_sanitize=address,undefined -Dunity=on -Dunity_size=12",
+            }
+          - {
+              id: ubuntu-clang,
+              platform: ubuntu,
+              cc: clang,
+              cpp: clang++,
+              setup_options: "-Dunity=on -Dunity_size=12",
+            }
+          - {
+              id: rockylinux-gcc,
+              platform: rockylinux,
+              cc: gcc,
+              cpp: g++,
+              setup_options: "-Dunity=on -Dunity_size=12",
+            }
+          - {
+              id: rockylinux-clang,
+              platform: rockylinux,
+              cc: clang,
+              cpp: clang++,
+              setup_options: "-Db_sanitize=address,undefined -Db_lundef=false -Dunity=on -Dunity_size=12",
+            }
 
     steps:
       - uses: actions/checkout@v2
@@ -63,12 +87,41 @@ jobs:
           load: true
           tags: ${{ matrix.cfg.id }}
           file: tests/docker/${{ matrix.cfg.platform }}.Dockerfile
-          build-args: |
-            cc=${{ matrix.cfg.cc }}
-            cxx=${{ matrix.cfg.cpp }}
-            setup_options=${{ matrix.cfg.setup_options }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Run tests
+      - name: Restore Compiler Cache
+        id: ccache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          # This ensures that every run saves cache even on cache hit
+          key: ${{ matrix.cfg.id }}-ccache-${{ github.run_id }}
+          restore-keys: |
+            ${{ matrix.cfg.id }}-ccache
+      - name: Start Docker container
         run: |
-          docker run ${{ matrix.cfg.id }} ninja -C builddir test
+          mkdir -p ${{ github.workspace }}/ccache
+          docker run -d --name ${{ matrix.cfg.id }} \
+          --mount=type=bind,source=${{ github.workspace }}/ccache,target=/ccache \
+          --mount=type=bind,source=${{ github.workspace }},target=/workdir \
+          ${{ matrix.cfg.id }} sleep infinity
+      - name: Build cps-config
+        run: |
+          docker exec \
+          -e CC="ccache ${{ matrix.cfg.cc }}" -e CXX="ccache ${{ matrix.cfg.cpp }}" \
+          -e CCACHE_DIR="/ccache" \
+          ${{ matrix.cfg.id }} \
+          bash -c "cd /workdir/ && meson builddir ${{ matrix.cfg.setup_options }} \
+          && ninja -C /workdir/builddir"
+      - name: Run Tests
+        run: |
+          docker exec ${{ matrix.cfg.id }} ninja -C /workdir/builddir
+      - name: Stop Docker Container
+        run: |
+          docker stop ${{ matrix.cfg.id }}
+      - name: Save Cache
+        id: ccache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ matrix.cfg.id }}-ccache-${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 subprojects/*
 !subprojects/*.wrap
+!subprojects/*.cmake
 .pixi/
 .cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+project(
+    cps-config
+    LANGUAGES CXX
+    VERSION 0.01
+)
+
+add_subdirectory(src)
+
+if (BUILD_TESTING)
+    include(CTest)
+    add_subdirectory(tests)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.22)
+file(READ VERSION VERSION)
+string(STRIP ${VERSION} VERSION_STRIPPED)
 project(
     cps-config
     LANGUAGES CXX
-    VERSION 0.01
+    VERSION ${VERSION_STRIPPED}
 )
 
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,7 +4,6 @@
     {
       "name": "default",
       "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "BUILD_TESTING": true
@@ -12,6 +11,21 @@
       "environment": {
         "CC": "gcc",
         "CXX": "g++"
+      }
+    },
+    {
+      "name": "fetch-deps",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "subprojects/provider.cmake"
+      }
+    },
+    {
+      "name": "shared",
+      "inherits": "fetch-deps",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": true,
+        "CMAKE_POSITION_INDEPENDENT_CODE": true
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja Multi-Config",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "BUILD_TESTING": true
+      },
+      "environment": {
+        "CC": "gcc",
+        "CXX": "g++"
+      }
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,41 @@
+# cps library
+add_library(
+    cps
+    cps/env.cpp
+    cps/loader.cpp
+    cps/printer.cpp
+    cps/search.cpp
+    cps/utils.cpp
+    cps/version.cpp
+)
+
+# Configure config.hpp
+configure_file(cps/config.hpp.in cps/config.hpp)
+
+target_include_directories(cps PUBLIC .)
+target_include_directories(cps PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Dependencies
+find_package(tl-expected 1.0 REQUIRED)
+target_link_libraries(cps PRIVATE tl::expected)
+
+find_package(fmt 8 REQUIRED)
+target_link_libraries(cps PRIVATE fmt::fmt)
+
+find_package(jsoncpp 1.9 REQUIRED)
+# Provide jsoncpp namespaced target when it's not available
+if (NOT TARGET JsonCpp::JsonCpp)
+    if (BUILD_SHARED_LIBS)
+        add_library(JsonCpp::JsonCpp ALIAS jsoncpp_lib)
+    else ()
+        add_library(JsonCpp::JsonCpp ALIAS jsoncpp_static)
+    endif ()
+endif ()
+target_link_libraries(cps PRIVATE JsonCpp::JsonCpp)
+
+# cps-config
+add_executable(cps-config cps-config/main.cpp)
+target_link_libraries(cps-config PRIVATE cps fmt::fmt)
+
+find_package(CLI11 2.1 REQUIRED)
+target_link_libraries(cps-config PRIVATE CLI11::CLI11)

--- a/src/cps/config.hpp.in
+++ b/src/cps/config.hpp.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define CPS_CONFIG_VERSION "${CMAKE_PROJECT_VERSION}"

--- a/subprojects/provider.cmake
+++ b/subprojects/provider.cmake
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.24)
+
+include(FetchContent)
+FetchContent_Declare(
+  GTest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+  URL_HASH SHA256=8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+)
+FetchContent_Declare(
+  tl-expected
+  URL https://github.com/TartanLlama/expected/archive/v1.1.0.tar.gz
+  URL_HASH SHA256=1db357f46dd2b24447156aaf970c4c40a793ef12a8a9c2ad9e096d9801368df6
+)
+FetchContent_Declare(
+  jsoncpp
+  URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.5.tar.gz
+  URL_HASH SHA256=f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
+)
+FetchContent_Declare(
+  fmt
+  URL https://github.com/fmtlib/fmt/archive/10.1.1.tar.gz
+  URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
+)
+FetchContent_Declare(
+  CLI11
+  URL https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.1.2.tar.gz
+  URL_HASH SHA256=26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb
+)
+
+macro(provide_dependency method dep_name)
+  if ("${dep_name}" MATCHES "^(GTest|tl-expected|jsoncpp|fmt|CLI11)$")
+    FetchContent_MakeAvailable(${dep_name})
+    set(${dep_name}_FOUND TRUE)
+  endif()
+endmacro()
+
+cmake_language(
+  SET_DEPENDENCY_PROVIDER provide_dependency
+  SUPPORTED_METHODS
+    FIND_PACKAGE
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(GTest REQUIRED)
+
+# Unit tests
+add_executable(cps-tests
+    loader.cpp
+    utils.cpp
+    version.cpp
+)
+target_link_libraries(cps-tests PRIVATE cps)
+target_link_libraries(cps-tests PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+)
+add_test(CpsTests cps-tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(GTest REQUIRED)
+find_package(GTest 1.10 REQUIRED)
 
 # Unit tests
 add_executable(cps-tests
@@ -11,4 +11,27 @@ target_link_libraries(cps-tests PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
-add_test(CpsTests cps-tests)
+
+include(GoogleTest)
+gtest_discover_tests(cps-tests)
+
+# Integration tests
+find_package(
+    Python 3.11
+    COMPONENTS Interpreter
+    REQUIRED
+)
+set(test_names "cps integration tests" "pkg-config compatibility")
+set(test_cases
+    "${CMAKE_CURRENT_SOURCE_DIR}/cases/cps-config.toml"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cases/pkg-config-compat.toml")
+foreach (test_name test_case IN ZIP_LISTS test_names test_cases)
+    add_test(
+        NAME ${test_name}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND
+        ${CMAKE_COMMAND} -E env CPS_PATH=${CMAKE_CURRENT_SOURCE_DIR}/cps-files
+        ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runner.py
+        $<TARGET_FILE:cps-config> ${test_case}
+    )
+endforeach ()

--- a/tests/docker/rockylinux.Dockerfile
+++ b/tests/docker/rockylinux.Dockerfile
@@ -20,7 +20,7 @@ RUN dnf install -y \
         expected-devel \
         gtest-devel \
         fmt-devel \
-        cxxopts-devel
+        cli11-devel
 RUN dnf clean all
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip

--- a/tests/docker/rockylinux.Dockerfile
+++ b/tests/docker/rockylinux.Dockerfile
@@ -25,17 +25,3 @@ RUN dnf clean all
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip
 RUN python3 -m pip install -U meson==0.64.1
-
-# Copy code
-WORKDIR /workarea
-COPY ./ ./
-
-ARG cc=gcc
-ARG cxx=g++
-ARG setup_options=
-
-# Build cps-config and tests
-ENV CC="ccache $cc" CXX="ccache $cxx"
-ENV CCACHE_DIR=/ccache
-RUN meson setup builddir $setup_options
-RUN --mount=type=cache,target=/ccache/ ninja -C builddir

--- a/tests/docker/rockylinux.Dockerfile
+++ b/tests/docker/rockylinux.Dockerfile
@@ -1,13 +1,12 @@
 FROM rockylinux:9
 
 # Enable EPEL
-RUN dnf update -y
-RUN dnf install -y 'dnf-command(config-manager)'
-RUN dnf config-manager --set-enabled crb -y
-RUN dnf install epel-release -y
-
 # Install dependencies
-RUN dnf install -y \
+RUN dnf update -y && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb -y && \
+    dnf install epel-release -y && \
+    dnf install -y \
         python3.11 \
         python3-pip \
         pkgconf-pkg-config \
@@ -20,8 +19,8 @@ RUN dnf install -y \
         expected-devel \
         gtest-devel \
         fmt-devel \
-        cli11-devel
-RUN dnf clean all
+        cli11-devel && \
+    dnf clean all
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip
 RUN python3 -m pip install -U meson==0.64.1

--- a/tests/docker/ubuntu.Dockerfile
+++ b/tests/docker/ubuntu.Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y \
         libexpected-dev \
         libgtest-dev \
         libfmt-dev \
-        libcxxopts-dev
+        libcli11-dev
 RUN apt-get clean
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip

--- a/tests/docker/ubuntu.Dockerfile
+++ b/tests/docker/ubuntu.Dockerfile
@@ -20,20 +20,3 @@ RUN apt-get clean
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip
 RUN python3 -m pip install -U meson==0.64.1
-
-# Copy code
-WORKDIR /workarea
-COPY ./ ./
-
-ARG cc=gcc
-ARG cxx=g++
-ARG setup_options=
-
-# Workaround Ubuntu broken ASan
-RUN sysctl vm.mmap_rnd_bits=28
-
-# Build cps-config and tests
-ENV CC="ccache $cc" CXX="ccache $cxx"
-ENV CCACHE_DIR=/ccache
-RUN meson setup builddir $setup_options
-RUN --mount=type=cache,target=/ccache/ ninja -C builddir

--- a/tests/docker/ubuntu.Dockerfile
+++ b/tests/docker/ubuntu.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
 
 # Install dependencies
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
         python3.11 \
         python3-pip \
         pkg-config \
@@ -15,8 +15,8 @@ RUN apt-get install -y \
         libexpected-dev \
         libgtest-dev \
         libfmt-dev \
-        libcli11-dev
-RUN apt-get clean
+        libcli11-dev && \
+    apt-get clean
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 10
 # Install meson from pip
 RUN python3 -m pip install -U meson==0.64.1

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -114,6 +114,8 @@ async def main() -> None:
         'list[Result]',
         await asyncio.gather(*[test(args.runner, c) for c in tests['case']]))
 
+    encountered_failure: bool = False
+
     for r in results:
         if r.status is not Status.PASS:
             print(f'{r.name}:', file=sys.stderr)
@@ -125,6 +127,10 @@ async def main() -> None:
             print('  command:', ' '.join(r.command), file=sys.stderr)
             print('\n')
 
+            encountered_failure = True
+
+    if encountered_failure:
+        exit(1)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Closes #50. Supersedes #78.

## Changes

This commit adds CMake as a supported build system alongside meson.

## Benefits

For a potentially low-level project like cps-config that many other C++
projects would have a reason to depend on, using CMake instead of meson
removes python as a transitive dependency for those C++ projects that
choose to leverage cps-config.

CMake is also just a very widely used build system for C++. Providing
CMake as an option may introduce a more familiar workflow for those that
would like to use, contribute to, or package cps-config.

## Future work

This introduces a fair amount of repetition between the cmake and meson
GitHub workflow files. Ideally this can be extracted into an action that
the two can share. I'll leave figuring out exactly how that works for
another day.

---

*This PR also refactors the CI process a bit to introduce the flexibility necessary for this change.*

# Perform build outside docker build process

## Changes

Currently, source code copied into docker images and the built binaries
are also stored there.

This commit extracts that process from docker build into the CI
pipeline.

## Benefits

- Docker image layers are cached. Moving source code and binaries out of
docker image reduces unnecessary cache, which are never going to be a
cache-hit for CI purposes anyway.
- This also adds flexibility to support other build systems other than
meson.