### PR TITLE
Add editorconfig for yaml and json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ insert_final_newline = true
 [meson.build]
 indent_size = 2
 
-[*.toml]
+[*.{toml,yml,json}]
 indent_size = 2


### PR DESCRIPTION
.yml files are used for GitHub Actions. Json files are used for cmake presets. This will make editorconfig consistent with styles used currently within the code base.