### PR TITLE
Fix CLI11's package name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   default_options : ['cpp_std=c++17', 'buildtype=debugoptimized', 'warning_level=2'],
 )
 
-dep_cli11 = dependency('cli11', version: '>=2.1')
+dep_cli11 = dependency('CLI11', version: '>=2.1')
 dep_expected = dependency('tl-expected', version : '>= 1.0', modules : ['tl::expected'])
 dep_jsoncpp = dependency('jsoncpp', version : '>= 1.9')
 dep_fmt = dependency('fmt', version : '>= 8')


### PR DESCRIPTION
The system-provided CLI11 has a capitalized name in their pkg-config files. Using the lowercase name will cause meson to fallback to cli11.wrap regardless of whether CLI11 has been installed or not.