### PR TITLE
Update path environment variables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ foreach t : [['cps integration tests', 'cps-config.toml'], ['pkg-config compatib
     python_interpreter,
     args: [files('tests/runner.py'), cps_config, 'tests/cases/' + t[1]],
     protocol : 'tap',
-    env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cps-files' },
+    env : {'CPS_PREFIX_PATH' : meson.current_source_dir() / 'tests' / 'cps-files' },
   )
 endforeach
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
     cps
     cps/env.cpp
     cps/loader.cpp
+    cps/platform.cpp
     cps/printer.cpp
     cps/search.cpp
     cps/utils.cpp

--- a/src/cps/env.cpp
+++ b/src/cps/env.cpp
@@ -14,6 +14,9 @@ namespace cps {
         if (const char * env_c = std::getenv("CPS_PATH")) {
             env.cps_path = std::string(env_c);
         }
+        if (const char * env_c = std::getenv("CPS_PREFIX_PATH")) {
+            env.cps_prefix_path = std::string(env_c);
+        }
         if (std::getenv("PKG_CONFIG_DEBUG_SPEW") || std::getenv("CPS_CONFIG_DEBUG_SPEW")) {
             env.debug_spew = true;
         }

--- a/src/cps/env.hpp
+++ b/src/cps/env.hpp
@@ -11,6 +11,7 @@ namespace cps {
 
     struct Env {
         std::optional<std::string> cps_path = std::nullopt;
+        std::optional<std::string> cps_prefix_path = std::nullopt;
         bool debug_spew = false;
     };
 

--- a/src/cps/platform.cpp
+++ b/src/cps/platform.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2024 Dylan Baker
+
+#include "cps/platform.hpp"
+
+namespace cps::platform {
+
+    fs::path libdir() { return "lib"; }
+
+    fs::path datadir() { return "share"; }
+
+} // namespace cps::platform

--- a/src/cps/platform.hpp
+++ b/src/cps/platform.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2024 Dylan Baker
+
+#include <filesystem>
+
+namespace cps::platform {
+
+    namespace fs = std::filesystem;
+
+    /// @brief  Get the platform specific location that libraries are installed in
+    /// @return A path segment for libraries to be installed in, relative to a prefix
+    fs::path libdir();
+
+    /// @brief  Get the platform specific location to install architecture agnostic data to
+    /// @return A path segment for data to be installed in, relative to a prefix
+    fs::path datadir();
+
+} // namespace cps::platform

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -6,6 +6,7 @@
 
 #include "cps/error.hpp"
 #include "cps/loader.hpp"
+#include "cps/platform.hpp"
 #include "cps/utils.hpp"
 #include "cps/version.hpp"
 
@@ -71,19 +72,6 @@ namespace cps::search {
             return out;
         }
 
-        fs::path libdir() {
-            // TODO: libdir needs to be configurable based on the personality,
-            //       and different name schemes.
-            //       This is complicated by the fact that different distros have
-            //       different schemes.
-            return "lib";
-        }
-
-        fs::path datadir() {
-            // TODO: needs to be configurable. see libdir above.
-            return "share";
-        }
-
         const std::vector<fs::path> nix_prefix{"/usr", "/usr/local"};
         // TODO: const std::vector<std::string> mac_prefix{""};
         // TODO: const std::vector<std::string> win_prefix{""};
@@ -100,8 +88,8 @@ namespace cps::search {
             // TODO: Windows specific paths
 
             // TODO: handle name-like search paths
-            paths.emplace_back(prefix / libdir() / "cps");
-            paths.emplace_back(prefix / datadir() / "cps");
+            paths.emplace_back(prefix / platform::libdir() / "cps");
+            paths.emplace_back(prefix / platform::datadir() / "cps");
 
             return paths;
         };

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -86,7 +86,7 @@ namespace cps::search {
                 cached_paths.reserve(nix.size());
                 cached_paths.insert(cached_paths.end(), nix.begin(), nix.end());
                 auto && paths = utils::split(env.cps_path.value());
-                cached_paths.reserve(paths.size());
+                cached_paths.reserve(cached_paths.size() + paths.size());
                 cached_paths.insert(cached_paths.end(), paths.begin(), paths.end());
             } else {
                 cached_paths = nix;

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ libcps = static_library(
   'cps',
   'cps/env.cpp',
   'cps/loader.cpp',
+  'cps/platform.cpp',
   'cps/printer.cpp',
   'cps/search.cpp',
   'cps/utils.cpp',

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach (test_name test_case IN ZIP_LISTS test_names test_cases)
         NAME ${test_name}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMAND
-        ${CMAKE_COMMAND} -E env CPS_PATH=${CMAKE_CURRENT_SOURCE_DIR}/cps-files
+        ${CMAKE_COMMAND} -E env CPS_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/cps-files
         ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runner.py
         $<TARGET_FILE:cps-config> ${test_case}
     )


### PR DESCRIPTION
#31 ended up being a lot to take all at once, so I decided to look at something smaller and easier

This just make the attempt to update the way that path searching is done to match the current spec, notably the addition of CPS_PREFIX_PATH and changes to CPS_PATH. This still leaves off the `<name-like>` patterns, just implements the base paths, and I'll plan to follow up with an update to #31 after this for adding the name-like patterns.

This still needs some additional tests, thus the draft status.