### PR TITLE
CI: use `meson setup` instead of just `meson`

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -111,7 +111,7 @@ jobs:
           -e CC="ccache ${{ matrix.cfg.cc }}" -e CXX="ccache ${{ matrix.cfg.cpp }}" \
           -e CCACHE_DIR="/ccache" \
           ${{ matrix.cfg.id }} \
-          bash -c "cd /workdir/ && meson builddir ${{ matrix.cfg.setup_options }} \
+          bash -c "meson setup /workdir/builddir /workdir ${{ matrix.cfg.setup_options }} \
           && ninja -C /workdir/builddir"
       - name: Run Tests
         run: |

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/workflows/test.yml"
+      - ".github/workflows/meson.yml"
       - "VERSION"
       - "meson.build"
       - "meson_options.txt"
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - ".github/workflows/test.yml"
+      - ".github/workflows/meson.yml"
       - "VERSION"
       - "meson.build"
       - "meson_options.txt"


### PR DESCRIPTION
The latter is deprecated, as it is an ambiguous alias for the former. Also make use of meson setup's sourcedir positional argument like cmake's -S argument while we're here.