### PR TITLE
Fix bug in loader for `package.requires`

### DIFF
--- a/src/cps/loader.cpp
+++ b/src/cps/loader.cpp
@@ -178,9 +178,9 @@ namespace cps::loader {
                 const Json::Value obj = *itr;
 
                 ret.emplace(key, Requirement{
-                                     CPS_TRY(get_optional<std::vector<std::string>>(require, name, "components"))
+                                     CPS_TRY(get_optional<std::vector<std::string>>(obj, name, "components"))
                                          .value_or(std::vector<std::string>{}),
-                                     CPS_TRY(get_optional<std::string>(require, name, "version")),
+                                     CPS_TRY(get_optional<std::string>(obj, name, "version")),
                                  });
             }
 

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -424,7 +424,7 @@ namespace cps::search {
                 auto && f = node->data.package.components.find(c_name);
                 utils::assert_fn(
                     f != node->data.package.components.end(),
-                    fmt::format("Could not find component {} of pacakge {}", c_name, node->data.package.name));
+                    fmt::format("Could not find component {} of package {}", c_name, node->data.package.name));
                 auto && comp = f->second;
 
                 // Convert prefix at this point because:

--- a/tests/cases/cps-config.toml
+++ b/tests/cases/cps-config.toml
@@ -92,9 +92,9 @@ expected = "-I/something -I/opt/include"
 
 [[case]]
 name = "Requires version, but version not set"
-cps = "needs-version.cps"
+cps = "needs-version"
 args = ["flags", "--modversion", "--print-errors", "--errors-to-stdout"]
-expected = "Could not find a CPS file for needs-version.cps"
+expected = "Could not find a dependency to satisfy needs-version"
 returncode = 1
 
 [[case]]

--- a/tests/cases/pkg-config-compat.toml
+++ b/tests/cases/pkg-config-compat.toml
@@ -48,7 +48,7 @@ expected = "-I/usr/local/include -I/opt/include"
 
 [[case]]
 name = "Requires version, but version not set"
-cps = "needs-version.cps"
+cps = "needs-version"
 args = ["pkg-config", "--modversion", "--print-errors", "--errors-to-stdout"]
-expected = "Could not find a CPS file for needs-version.cps"
+expected = "Could not find a dependency to satisfy needs-version"
 returncode = 1


### PR DESCRIPTION
We looked in the wrong JSON object for these optional fields, so they were silently ignored. Then our test that was supposed to look for this got broken, and was instead tripping up in another place.