### PR TITLE
Fix test name

### DIFF
--- a/tests/cases/cps-config.toml
+++ b/tests/cases/cps-config.toml
@@ -91,7 +91,7 @@ args = ["flags", "--cflags-only-I"]
 expected = "-I/something -I/opt/include"
 
 [[case]]
-name = "Requires version, but version not set"
+name = "library not found"
 cps = "needs-version.cps"
 args = ["flags", "--modversion", "--print-errors", "--errors-to-stdout"]
 expected = "Could not find a CPS file for needs-version.cps"

--- a/tests/cases/pkg-config-compat.toml
+++ b/tests/cases/pkg-config-compat.toml
@@ -47,7 +47,7 @@ args = ["pkg-config", "--cflags-only-I"]
 expected = "-I/usr/local/include -I/opt/include"
 
 [[case]]
-name = "Requires version, but version not set"
+name = "library not found"
 cps = "needs-version.cps"
 args = ["pkg-config", "--modversion", "--print-errors", "--errors-to-stdout"]
 expected = "Could not find a CPS file for needs-version.cps"


### PR DESCRIPTION
The changed test case is testing for a case where a library is not found. The current test name seems inaccurate.