### PR TITLE
Compatibility with GCC 14

### DIFF
--- a/src/cps/printer.cpp
+++ b/src/cps/printer.cpp
@@ -4,6 +4,7 @@
 
 #include "cps/printer.hpp"
 
+#include <algorithm>
 #include <fmt/format.h>
 #include <tl/expected.hpp>
 

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -13,6 +13,7 @@
 #include <fmt/core.h>
 #include <tl/expected.hpp>
 
+#include <algorithm>
 #include <deque>
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
With GCC 14, <algorithm> is no longer transitively included and now has to be included directly.