### PR TITLE
Switch to nlohmann json

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Brew Install
-        run: brew install pkg-config ninja cli11 googletest jsoncpp fmt cmake meson tl-expected
+        run: brew install pkg-config ninja cli11 googletest nlohmann-json fmt cmake meson tl-expected
       - name: Build cps-config
         run: |
           meson setup builddir -Dunity=on -Dunity_size=12

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
 
 dep_cli11 = dependency('CLI11', version: '>=2.1')
 dep_expected = dependency('tl-expected', version : '>= 1.0', modules : ['tl::expected'])
-dep_jsoncpp = dependency('jsoncpp', version : '>= 1.9')
+dep_json = dependency('nlohmann_json', version : '>= 3.7')
 dep_fmt = dependency('fmt', version : '>= 8')
 
 cpp = meson.get_compiler('cpp')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,16 +23,8 @@ target_link_libraries(cps PRIVATE tl::expected)
 find_package(fmt 8 REQUIRED)
 target_link_libraries(cps PRIVATE fmt::fmt)
 
-find_package(jsoncpp 1.9 REQUIRED)
-# Provide jsoncpp namespaced target when it's not available
-if (NOT TARGET JsonCpp::JsonCpp)
-    if (BUILD_SHARED_LIBS)
-        add_library(JsonCpp::JsonCpp ALIAS jsoncpp_lib)
-    else ()
-        add_library(JsonCpp::JsonCpp ALIAS jsoncpp_static)
-    endif ()
-endif ()
-target_link_libraries(cps PRIVATE JsonCpp::JsonCpp)
+find_package(nlohmann_json 3.7 REQUIRED)
+target_link_libraries(cps PRIVATE nlohmann_json::nlohmann_json)
 
 # cps-config
 add_executable(cps-config cps-config/main.cpp)

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,7 +15,7 @@ libcps = static_library(
   'cps/utils.cpp',
   'cps/version.cpp',
   conf_h,
-  dependencies : [dep_jsoncpp, dep_expected, dep_fmt],
+  dependencies : [dep_json, dep_expected, dep_fmt],
   cpp_args : warn_args,
   include_directories: [cps_include_dir, conf_include_dir],
 )

--- a/subprojects/jsoncpp.wrap
+++ b/subprojects/jsoncpp.wrap
@@ -1,8 +1,0 @@
-[wrap-file]
-directory = jsoncpp-1.9.5
-source_url = https://github.com/open-source-parsers/jsoncpp/archive/1.9.5.tar.gz
-source_filename = jsoncpp-1.9.5.tar.gz
-source_hash = f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
-
-[provide]
-jsoncpp = jsoncpp_dep

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nlohmann_json-3.11.2
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
+source_filename = nlohmann_json-3.11.2.zip
+source_hash = e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed
+wrapdb_version = 3.11.2-1
+
+[provide]
+nlohmann_json = nlohmann_json_dep

--- a/subprojects/provider.cmake
+++ b/subprojects/provider.cmake
@@ -12,9 +12,9 @@ FetchContent_Declare(
   URL_HASH SHA256=1db357f46dd2b24447156aaf970c4c40a793ef12a8a9c2ad9e096d9801368df6
 )
 FetchContent_Declare(
-  jsoncpp
-  URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.5.tar.gz
-  URL_HASH SHA256=f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
+  nlohmann_json
+  URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.tar.gz
+  URL_HASH SHA256=d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273
 )
 FetchContent_Declare(
   fmt
@@ -28,7 +28,7 @@ FetchContent_Declare(
 )
 
 macro(provide_dependency method dep_name)
-  if ("${dep_name}" MATCHES "^(GTest|tl-expected|jsoncpp|fmt|CLI11)$")
+  if ("${dep_name}" MATCHES "^(GTest|tl-expected|nlohmann_json|fmt|CLI11)$")
     FetchContent_MakeAvailable(${dep_name})
     set(${dep_name}_FOUND TRUE)
   endif()

--- a/tests/docker/rockylinux.Dockerfile
+++ b/tests/docker/rockylinux.Dockerfile
@@ -15,7 +15,7 @@ RUN dnf update -y && \
         g++ \
         ninja-build \
         cmake \
-        jsoncpp-devel \
+        json-devel \
         expected-devel \
         gtest-devel \
         fmt-devel \

--- a/tests/docker/ubuntu.Dockerfile
+++ b/tests/docker/ubuntu.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
         g++ \
         ninja-build \
         cmake \
-        libjsoncpp-dev \
+        nlohmann-json3-dev \
         libexpected-dev \
         libgtest-dev \
         libfmt-dev \

--- a/tests/loader.cpp
+++ b/tests/loader.cpp
@@ -31,7 +31,7 @@ namespace cps::utils::test {
     "components": {
         "default": {
             "type": "archive",
-            "location": "/",
+            "location": "/"
         }
     }
 }
@@ -211,25 +211,25 @@ namespace cps::utils::test {
     "components": {
         "a": {
             "type": "archive",
-            "location": "/",
+            "location": "/"
         },
         "b": {
-            "type": "dylib",
+            "type": "dylib"
         },
         "c": {
-            "type": "module",
+            "type": "module"
         },
         "d": {
-            "type": "jar",
+            "type": "jar"
         },
         "e": {
-            "type": "interface",
+            "type": "interface"
         },
         "f": {
-            "type": "symbolic",
+            "type": "symbolic"
         },
         "g": {
-            "type": "executable",
+            "type": "executable"
         }
     }
 }
@@ -246,11 +246,11 @@ namespace cps::utils::test {
     "components": {
         "a": {
             "type": "archive",
-            "location": "/",
+            "location": "/"
         },
         "b": {
-            "type": "not_recognized_type_is_valid_but_ignored",
-        },
+            "type": "not_recognized_type_is_valid_but_ignored"
+        }
     }
 }
 )"s);


### PR DESCRIPTION
nlohmann json is better maintained and has a better project setup that allows it to be consumed with less effort, at least on the CMake side. In contrast, jsoncpp only has 2 commits since 2023.

According to a rather dated benchmark [1], nlohmann json has better JSON standard conformance, e.g. no trailing comma, than jsoncpp and has better performance. Although this benchmark was conducted a while back, jsoncpp hasn't been significantly updated for a long while. I'd be surprised if the numbers would move in jsoncpp's favor.

[1] https://github.com/miloyip/nativejson-benchmark