### PR TITLE
search: fix use of cps_path

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -115,7 +115,7 @@ jobs:
           && ninja -C /workdir/builddir"
       - name: Run Tests
         run: |
-          docker exec ${{ matrix.cfg.id }} ninja -C /workdir/builddir
+          docker exec ${{ matrix.cfg.id }} ninja -C /workdir/builddir test
       - name: Stop Docker Container
         run: |
           docker stop ${{ matrix.cfg.id }}

--- a/src/cps/loader.cpp
+++ b/src/cps/loader.cpp
@@ -281,19 +281,20 @@ namespace cps::loader {
 
     Platform::Platform() = default;
 
-    tl::expected<Package, std::string> load(std::istream & input_buffer, std::string const & filename) {
+    tl::expected<Package, std::string> load(std::istream & input_buffer, const std::filesystem::path & filename) {
         nlohmann::json root;
         try {
             root = nlohmann::json::parse(input_buffer);
         } catch (const nlohmann::json::exception & ex) {
             return tl::make_unexpected(
-                fmt::format("Exception caught while parsing json for `{}.cps`\n{}", filename, ex.what()));
+                fmt::format("Exception caught while parsing json for `{}.cps`\n{}", std::string{filename}, ex.what()));
         }
 
         auto const name = CPS_TRY(get_required<std::string>(root, "package", "name"));
         auto const cps_version = CPS_TRY(get_required<std::string>(root, "package", "cps_version"));
         auto const components = CPS_TRY(get_required<Components>(root, "package", "components"));
-        auto const cps_path = CPS_TRY(get_optional<std::string>(root, "package", "cps_path")).value_or(filename);
+        auto const cps_path =
+            CPS_TRY(get_optional<std::string>(root, "package", "cps_path")).value_or(filename.parent_path());
         auto const default_components =
             CPS_TRY(get_optional<std::vector<std::string>>(root, "package", "default_components"));
         auto const platform = std::nullopt; // TODO: parse platform

--- a/src/cps/loader.cpp
+++ b/src/cps/loader.cpp
@@ -1,5 +1,5 @@
 // Copyright © 2023-2024 Dylan Baker
-// Copyright © 2024 Bret Brown
+// Copyright © 2024 Dylan Baker
 // SPDX-License-Identifier: MIT
 
 #include "cps/loader.hpp"
@@ -293,8 +293,7 @@ namespace cps::loader {
         auto const name = CPS_TRY(get_required<std::string>(root, "package", "name"));
         auto const cps_version = CPS_TRY(get_required<std::string>(root, "package", "cps_version"));
         auto const components = CPS_TRY(get_required<Components>(root, "package", "components"));
-        auto const cps_path =
-            CPS_TRY(get_optional<std::string>(root, "package", "cps_path")).value_or(filename.parent_path());
+        auto const cps_path = CPS_TRY(get_optional<std::string>(root, "package", "cps_path"));
         auto const default_components =
             CPS_TRY(get_optional<std::vector<std::string>>(root, "package", "default_components"));
         auto const platform = std::nullopt; // TODO: parse platform
@@ -315,6 +314,7 @@ namespace cps::loader {
             .cps_version = std::move(cps_version),
             .components = std::move(components),
             .cps_path = std::move(cps_path),
+            .filename = filename,
             .default_components = std::move(default_components),
             .platform = std::move(platform),
             .require = std::move(require), // requires is a keyword

--- a/src/cps/loader.hpp
+++ b/src/cps/loader.hpp
@@ -8,6 +8,7 @@
 
 #include <tl/expected.hpp>
 
+#include <filesystem>
 #include <istream>
 #include <optional>
 #include <string>
@@ -142,6 +143,6 @@ namespace cps::loader {
         version::Schema version_schema;
     };
 
-    tl::expected<Package, std::string> load(std::istream & input_buffer, std::string const & filename);
+    tl::expected<Package, std::string> load(std::istream & input_buffer, const std::filesystem::path & filename);
 
 } // namespace cps::loader

--- a/src/cps/loader.hpp
+++ b/src/cps/loader.hpp
@@ -135,7 +135,8 @@ namespace cps::loader {
         // TODO: compat-version
         // TODO: configuration
         // TODO: configurations
-        std::string cps_path;
+        std::optional<std::string> cps_path;
+        std::string filename;
         std::optional<std::vector<std::string>> default_components;
         std::optional<Platform> platform;
         Requires require; // Requires is a keyword

--- a/src/cps/printer.cpp
+++ b/src/cps/printer.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <tl/expected.hpp>
 
 namespace cps::printer {

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -209,7 +209,7 @@ namespace cps::search {
 
                 std::ifstream file;
                 file.open(path);
-                auto n = std::make_shared<Node>(CPS_TRY(loader::load(file, path.parent_path())));
+                auto n = std::make_shared<Node>(CPS_TRY(loader::load(file, path)));
 
                 cache.emplace(name, n);
                 return n;

--- a/tests/cases/cps-config.toml
+++ b/tests/cases/cps-config.toml
@@ -76,7 +76,13 @@ expected = "-I/err"
 name = "prefix set"
 cps = "cps-path-set"
 args = ["flags", "--cflags-only-I", "--libs-only-l"]
-expected = "-I/sentinel/err -l/sentinel/lib/libfoo.a"
+expected = "-I{prefix}/err -l{prefix}/lib/libfoo.a"
+
+[[case]]
+name = "prefix set (called by path)"
+cps = "{prefix}/cps-path-set.cps"
+args = ["flags", "--cflags-only-I", "--libs-only-l"]
+expected = "-I{prefix}/err -l{prefix}/lib/libfoo.a"
 
 [[case]]
 name = "prefix calculated"

--- a/tests/cps-files/lib/cps/cps-path-set.cps
+++ b/tests/cps-files/lib/cps/cps-path-set.cps
@@ -1,7 +1,7 @@
 {
     "name": "cps-path-set",
     "cps_version": "0.10.0",
-    "cps_path": "/sentinel/lib/cps/",
+    "cps_path": "@prefix@/lib/cps/",
     "version": "1.0.0",
     "components": {
         "default": {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -67,7 +67,8 @@ def unordered_compare(out, expected):
     return sorted(out_parts) == sorted(expected_parts)
 
 async def test(runner: str, case_: TestCase) -> Result:
-    cmd = [runner] + case_['args'] + [case_['cps']]
+    cmd = [runner] + case_['args']
+    cmd.append(case_['cps'].replace('{prefix}', os.path.join(PREFIX, 'lib/cps')))
     if 'mode' in case_:
         cmd.extend([f"--format={case_['mode']}"])
 


### PR DESCRIPTION
This must be `@prefix@` prefaced, and is used to describe how the prefix is calculated when the cps file is passed by path, not to calculate a prefix which is different than where the cps file is located.