### PR TITLE
Fix compilation on Windows mingw

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(cps PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Dependencies
 find_package(tl-expected 1.0 REQUIRED)
-target_link_libraries(cps PRIVATE tl::expected)
+target_link_libraries(cps PUBLIC tl::expected)
 
 find_package(fmt 8 REQUIRED)
 target_link_libraries(cps PRIVATE fmt::fmt)

--- a/src/cps/loader.cpp
+++ b/src/cps/loader.cpp
@@ -305,7 +305,7 @@ namespace cps::loader {
             root = nlohmann::json::parse(input_buffer);
         } catch (const nlohmann::json::exception & ex) {
             return tl::make_unexpected(
-                fmt::format("Exception caught while parsing json for `{}.cps`\n{}", std::string{filename}, ex.what()));
+                fmt::format("Exception caught while parsing json for `{}.cps`\n{}", filename.string(), ex.what()));
         }
 
         auto const name = CPS_TRY(get_required<std::string>(root, "package", "name"));
@@ -332,7 +332,7 @@ namespace cps::loader {
             .cps_version = std::move(cps_version),
             .components = std::move(components),
             .cps_path = std::move(cps_path),
-            .filename = filename,
+            .filename = filename.string(),
             .default_components = std::move(default_components),
             .platform = std::move(platform),
             .require = std::move(require), // requires is a keyword

--- a/src/cps/search.cpp
+++ b/src/cps/search.cpp
@@ -323,7 +323,7 @@ namespace cps::search {
                     if (p.stem() != f.stem()) {
                         return tl::unexpected(
                             fmt::format("filepath and cps_path have non overlapping stems, prefix: {}, filename {}",
-                                        std::string{p}, std::string{f}));
+                                        p.string(), f.string()));
                     }
                     p = p.parent_path();
                     f = f.parent_path();
@@ -440,7 +440,7 @@ namespace cps::search {
                     for (auto it = split.begin() + 1; it != split.end(); ++it) {
                         p /= *it;
                     }
-                    return p;
+                    return p.string();
                 }
                 return s;
             };


### PR DESCRIPTION
This commit fixes two issues on Windows:
1. MSSTL does not provide an implicit conversion from fs::path to string.
2. fmt and tl-expected are included in are in libcps header files and are thus leaked into targets that depend on libcps. Setting fmt and tl-expected's visibility to PUBLIC solves build failures.