### PR TITLE
Finish implementing "simple" version comparison

### DIFF
--- a/src/cps/version.cpp
+++ b/src/cps/version.cpp
@@ -48,6 +48,48 @@ namespace cps::version {
             }
         }
 
+        enum comp_value {
+            eq,
+            ne,
+            unknown,
+        };
+
+        comp_value compare(const uint64_t & left, Operator op, const uint64_t & right) {
+            switch (op) {
+            case Operator::eq:
+                if (left != right) {
+                    return comp_value::ne;
+                }
+                break;
+            case Operator::le:
+                if (left > right) {
+                    return comp_value::ne;
+                }
+                break;
+            case Operator::ge:
+                if (left < right) {
+                    return comp_value::ne;
+                }
+                break;
+            case Operator::lt:
+                if (left < right) {
+                    return comp_value::eq;
+                }
+                break;
+            case Operator::gt:
+                if (left > right) {
+                    return comp_value::eq;
+                }
+                break;
+            case Operator::ne:
+                if (left != right) {
+                    return comp_value::eq;
+                }
+                break;
+            }
+            return comp_value::unknown;
+        }
+
         tl::expected<bool, std::string> simple_compare(std::string_view l, Operator op, std::string_view r) {
             // TODO: handle the -.* or +.* ending
             std::vector<uint64_t> left = CPS_TRY(as_numbers(l));
@@ -59,36 +101,12 @@ namespace cps::version {
                 const uint64_t lv = left[i];
                 const uint64_t rv = right[i];
 
-                switch (op) {
-                case Operator::eq:
-                    if (lv != rv) {
-                        return false;
-                    }
-                    break;
-                case Operator::le:
-                    if (lv > rv) {
-                        return false;
-                    }
-                    break;
-                case Operator::ge:
-                    if (lv < rv) {
-                        return false;
-                    }
-                    break;
-                case Operator::lt:
-                    if (lv < rv) {
-                        return true;
-                    }
-                    break;
-                case Operator::gt:
-                    if (lv > rv) {
-                        return true;
-                    }
-                    break;
-                case Operator::ne:
-                    if (lv != rv) {
-                        return true;
-                    }
+                switch (compare(lv, op, rv)) {
+                case comp_value::eq:
+                    return true;
+                case comp_value::ne:
+                    return false;
+                case comp_value::unknown:
                     break;
                 }
             }

--- a/src/cps/version.cpp
+++ b/src/cps/version.cpp
@@ -10,6 +10,7 @@
 #include <fmt/core.h>
 
 #include <cstdint>
+#include <optional>
 
 namespace cps::version {
 
@@ -48,63 +49,134 @@ namespace cps::version {
             }
         }
 
+        enum class simple_div {
+            none = 0,
+            minus = 1,
+            plus = 2,
+        };
+
+        tl::expected<std::tuple<std::string, simple_div, std::optional<std::string>>, std::string>
+        split_plus_minus(std::string_view raw) {
+            std::vector<std::string> split;
+            if (raw.find("+") != raw.npos) {
+                if (raw.find("-") != raw.npos) {
+                    return tl::make_unexpected("Found both a '-' and a '+' in a simple version");
+                }
+                split = utils::split(raw, "+");
+                if (split.size() != 2) {
+                    return tl::make_unexpected("More than 1 '+' in a simple version");
+                }
+                return std::make_tuple(split[0], simple_div::plus, split[1]);
+            }
+            if (raw.find("-") != raw.npos) {
+                if (raw.find("+") != raw.npos) {
+                    return tl::make_unexpected("Found both a '-' and a '+' in a simple version");
+                }
+                split = utils::split(raw, "-");
+                if (split.size() != 2) {
+                    return tl::make_unexpected("More than 1 '-' in a simple version");
+                }
+                return std::make_tuple(split[0], simple_div::minus, split[1]);
+            }
+            return std::make_tuple(std::string{raw}, simple_div::none, std::nullopt);
+        };
+
         enum comp_value {
-            eq,
-            ne,
+            yes,
+            no,
             unknown,
         };
 
-        comp_value compare(const uint64_t & left, Operator op, const uint64_t & right) {
+        template <typename T> comp_value compare(const T & left, Operator op, const T & right) {
             switch (op) {
             case Operator::eq:
                 if (left != right) {
-                    return comp_value::ne;
+                    return comp_value::no;
                 }
                 break;
             case Operator::le:
                 if (left > right) {
-                    return comp_value::ne;
+                    return comp_value::no;
                 }
                 break;
             case Operator::ge:
                 if (left < right) {
-                    return comp_value::ne;
+                    return comp_value::no;
                 }
                 break;
             case Operator::lt:
                 if (left < right) {
-                    return comp_value::eq;
+                    return comp_value::yes;
                 }
                 break;
             case Operator::gt:
                 if (left > right) {
-                    return comp_value::eq;
+                    return comp_value::yes;
                 }
                 break;
             case Operator::ne:
                 if (left != right) {
-                    return comp_value::eq;
+                    return comp_value::yes;
                 }
                 break;
             }
             return comp_value::unknown;
         }
 
-        tl::expected<bool, std::string> simple_compare(std::string_view l, Operator op, std::string_view r) {
-            // TODO: handle the -.* or +.* ending
+        tl::expected<comp_value, std::string> compare_numbers(std::string & l, Operator op, std::string_view r) {
             std::vector<uint64_t> left = CPS_TRY(as_numbers(l));
             std::vector<uint64_t> right = CPS_TRY(as_numbers(r));
             equalize_length(left, right);
 
-            // TODO: this is so ugly
             for (size_t i = 0; i < left.size(); ++i) {
                 const uint64_t lv = left[i];
                 const uint64_t rv = right[i];
 
-                switch (compare(lv, op, rv)) {
-                case comp_value::eq:
+                comp_value v = compare(lv, op, rv);
+                if (v != comp_value::unknown) {
+                    return v;
+                }
+            }
+            return comp_value::unknown;
+        }
+
+        tl::expected<bool, std::string> simple_compare(std::string_view l, Operator op, std::string_view r) {
+            auto [lfirst, ldiv, lrest] = CPS_TRY(split_plus_minus(l));
+            auto [rfirst, rdiv, rrest] = CPS_TRY(split_plus_minus(r));
+
+            switch (CPS_TRY(compare_numbers(lfirst, op, rfirst))) {
+            case comp_value::yes:
+                return true;
+            case comp_value::no:
+                return false;
+            case comp_value::unknown:
+                break;
+            }
+
+            switch (compare(lrest.has_value(), op, rrest.has_value())) {
+            case comp_value::yes:
+                return true;
+            case comp_value::no:
+                return false;
+            case comp_value::unknown:
+                break;
+            }
+
+            // If we do have a rest (both have rest), then we need to compare those as well.
+            if (rrest) {
+                switch (compare(ldiv, op, rdiv)) {
+                case comp_value::yes:
                     return true;
-                case comp_value::ne:
+                case comp_value::no:
+                    return false;
+                case comp_value::unknown:
+                    break;
+                }
+
+                switch (CPS_TRY(compare_numbers(lrest.value(), op, rrest.value()))) {
+                case comp_value::yes:
+                    return true;
+                case comp_value::no:
                     return false;
                 case comp_value::unknown:
                     break;

--- a/tests/version.cpp
+++ b/tests/version.cpp
@@ -53,6 +53,7 @@ namespace cps::version::test {
                 std::tuple("0.0.0", Operator::gt, "3.0", false), std::tuple("0.0.0", Operator::le, "0.0", true),
                 std::tuple("0.0.0", Operator::le, "3.0", true), std::tuple("6.0.0", Operator::le, "3.0", false),
                 std::tuple("0.0.0", Operator::lt, "3.0", true), std::tuple("0.4.0", Operator::lt, "0.0", false),
+                std::tuple("001.0.0", Operator::eq, "1", true),
                 std::tuple("0.0.0", Operator::ne, "10.0", true), std::tuple("0.0.0", Operator::ne, "0", false)));
     } // unnamed namespace
 } // namespace cps::version::test

--- a/tests/version.cpp
+++ b/tests/version.cpp
@@ -53,7 +53,10 @@ namespace cps::version::test {
                 std::tuple("0.0.0", Operator::gt, "3.0", false), std::tuple("0.0.0", Operator::le, "0.0", true),
                 std::tuple("0.0.0", Operator::le, "3.0", true), std::tuple("6.0.0", Operator::le, "3.0", false),
                 std::tuple("0.0.0", Operator::lt, "3.0", true), std::tuple("0.4.0", Operator::lt, "0.0", false),
-                std::tuple("001.0.0", Operator::eq, "1", true),
-                std::tuple("0.0.0", Operator::ne, "10.0", true), std::tuple("0.0.0", Operator::ne, "0", false)));
+                std::tuple("001.0.0", Operator::eq, "1", true), std::tuple("001.0.0+5", Operator::eq, "1", false),
+                std::tuple("001.0.0-1", Operator::eq, "1-1", true), std::tuple("1+1", Operator::gt, "1", true),
+                std::tuple("1-1", Operator::gt, "1", true), std::tuple("1+1", Operator::gt, "1-1", true),
+                std::tuple("1+1", Operator::le, "1-1", false), std::tuple("0.0.0", Operator::ne, "10.0", true),
+                std::tuple("0.0.0", Operator::ne, "0", false)));
     } // unnamed namespace
 } // namespace cps::version::test


### PR DESCRIPTION
I'd previously punted on the `+` and `-` bits, but now that's done too.