### PR TITLE
utils: Don't include config.hpp in utils.hpp

### DIFF
--- a/src/cps/utils.hpp
+++ b/src/cps/utils.hpp
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright © 2024 Dylan Baker
+// Copyright © 2024-2025 Dylan Baker
 // Copyright © 2024 Bret Brown
 
 #pragma once
-
-#include "cps/config.hpp"
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
It's not actually used, but can cause rebuilds that are unnecessary.