### PR TITLE
search: handle arbitrarily deep self requires references

### DIFF
--- a/tests/cases/cps-config.toml
+++ b/tests/cases/cps-config.toml
@@ -123,7 +123,13 @@ args = ["flags", "--component", "star_values_override", "--cflags", "--print-err
 expected = "-fvectorize -I/usr/local/include -I/opt/include -DBAR=2 -DFOO=1 -DOTHER"
 
 [[case]]
-name = "Sets compat_version"
-cps = "needs-compat-version"
-args = ["flags", "--libs", "--print-errors"]
-expected = "-l/usr/lib/libfoo.a"
+name = "requires component from self"
+cps = "full"
+args = ["flags", "--component", "requires-self-helper", "--cflags", "--print-errors"]
+expected = "-fvectorize -I/usr/local/include -I/opt/include -DBAR=2 -DFOO=1 -DOTHER"
+
+[[case]]
+name = "requires component from self nested"
+cps = "full"
+args = ["flags", "--component", "requires-self", "--cflags", "--print-errors"]
+expected = "-fvectorize -I/usr/local/include -I/opt/include -DBAR=2 -DFOO=1 -DOTHER"

--- a/tests/cps-files/lib/cps/full.cps
+++ b/tests/cps-files/lib/cps/full.cps
@@ -112,6 +112,20 @@
             },
             "location": "/something/lib/libfoo.so.1.2.0",
             "link_location": "/something/lib/libfoo.so"
+        },
+        "requires-self-helper": {
+            "type": "interface",
+            "requires": [
+                ":star_values"
+            ]
+        },
+        "requires-self": {
+            "type": "dylib",
+            "location": "/something/lib/libbar.so.1.8.1",
+            "link_location": "/something/lib/libbar.so",
+            "requires": [
+                ":requires-self-helper"
+            ]
         }
     },
     "default_components": [


### PR DESCRIPTION
This requires that all requirements of the current node be processed before starting on any of its children, otherwise we may not select all of the correct components from those children.

I still don't think the algorithm is fundamentally correct, since we could still end up visiting the same child more than once, and could fail to get all of the requirements we need for each child before visiting it. However, this is an improvement over the status quo, and does fix the linked issue.

Fixes: #101