### PR TITLE
Initial Windows support

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -138,3 +138,32 @@ jobs:
           ninja -C builddir
       - name: Run tests
         run: meson test -C builddir
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            flex
+            bison
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-python-pip
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-python-certifi
+      - uses: actions/checkout@v3
+      - name: Install system certs for python
+        run: |
+          pip install pip-system-certs
+          echo "REQUESTS_CA_BUNDLE=$(python -m certifi)" >> $GITHUB_ENV
+          echo "SSL_CERT_FILE=$(python -m certifi)" >> $GITHUB_ENV
+      - name: Build cps-config
+        run: |
+          meson setup builddir -Dunity=on -Dunity_size=12
+          ninja -C builddir
+      - name: Run tests
+        run: meson test -C builddir

--- a/src/cps/env.cpp
+++ b/src/cps/env.cpp
@@ -2,6 +2,7 @@
 // Copyright © 2024 Tyler Weaver
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
 #include <cstdlib>
 #include <string>
 
@@ -10,17 +11,34 @@
 
 namespace cps {
 
+    namespace {
+        std::vector<fs::path> get_paths(const char * input) {
+            const char * path_sep =
+#ifdef _WIN32
+                ";"
+#else
+                ":"
+#endif
+                ;
+            std::vector<std::string> path_strs = utils::split(input, path_sep);
+            auto result = std::vector<fs::path>{};
+            std::transform(path_strs.begin(), path_strs.end(), std::back_inserter(result),
+                           [](const std::string & s) { return fs::path{s}; });
+            return result;
+        }
+    } // namespace
+
     Env get_env() {
         auto env = Env{};
         if (const char * env_c = std::getenv("CPS_PATH")) {
-            env.cps_path = std::string(env_c);
+            env.cps_path = get_paths(env_c);
         }
         if (const char * env_c = std::getenv("CPS_PREFIX_PATH")) {
             // TODO: Windows
-            env.cps_prefix_path = utils::split(env_c, ":");
+            env.cps_prefix_path = get_paths(env_c);
         }
         if (const char * env_c = std::getenv("PKG_CONFIG_PATH")) {
-            env.pc_path = std::string(env_c);
+            env.pc_path = get_paths(env_c);
         }
         if (std::getenv("PKG_CONFIG_DEBUG_SPEW") || std::getenv("CPS_CONFIG_DEBUG_SPEW")) {
             env.debug_spew = true;

--- a/src/cps/env.hpp
+++ b/src/cps/env.hpp
@@ -4,16 +4,19 @@
 
 #pragma once
 
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
 
 namespace cps {
 
+    namespace fs = std::filesystem;
+
     struct Env {
-        std::optional<std::string> cps_path = std::nullopt;
-        std::optional<std::vector<std::string>> cps_prefix_path = std::nullopt;
-        std::optional<std::string> pc_path = std::nullopt;
+        std::optional<std::vector<fs::path>> cps_path = std::nullopt;
+        std::optional<std::vector<fs::path>> cps_prefix_path = std::nullopt;
+        std::optional<std::vector<fs::path>> pc_path = std::nullopt;
         bool debug_spew = false;
     };
 

--- a/src/cps/loader.hpp
+++ b/src/cps/loader.hpp
@@ -18,6 +18,8 @@
 
 namespace cps::loader {
 
+    namespace fs = std::filesystem;
+
     /// @brief  Known Programming languages
     enum class KnownLanguages {
         c,
@@ -56,14 +58,15 @@ namespace cps::loader {
         std::optional<std::string> value;
     };
 
-    using LangValues = std::unordered_map<KnownLanguages, std::vector<std::string>>;
+    using LangStrings = std::unordered_map<KnownLanguages, std::vector<std::string>>;
+    using LangPaths = std::unordered_map<KnownLanguages, std::vector<fs::path>>;
 
     using Defines = std::unordered_map<KnownLanguages, std::vector<Define>>;
 
     struct Component {
         Type type;
-        LangValues compile_flags;
-        LangValues includes;
+        LangStrings compile_flags;
+        LangPaths includes;
         Defines definitions;
         // TODO: configurations
         // TODO: std::vector<std::string> link_features;
@@ -79,9 +82,9 @@ namespace cps::loader {
     class Configuration {
       public:
         Configuration();
-        Configuration(LangValues cflags);
+        Configuration(LangStrings cflags);
 
-        LangValues compile_flags;
+        LangStrings compile_flags;
         // TODO: LangValues definitions;
         // TODO: LangValues includes;
         // TODO: std::vector<std::string> link_features;
@@ -131,8 +134,8 @@ namespace cps::loader {
         std::optional<std::string> compat_version;
         // TODO: configuration
         // TODO: configurations
-        std::optional<std::string> cps_path;
-        std::string prefix;
+        std::optional<fs::path> cps_path;
+        fs::path prefix;
         std::string filename;
         std::optional<std::vector<std::string>> default_components;
         std::optional<Platform> platform;

--- a/src/cps/pc_compat/meson.build
+++ b/src/cps/pc_compat/meson.build
@@ -4,7 +4,7 @@ prog_flex = find_program('', required : false)
 flex_args = []
 prog_bison = find_program('', required : false)
 if host_machine.system() == 'windows'
-  prog_flex = find_program('win_flex', required : false, version : _flex_vesrion)
+  prog_flex = find_program('win_flex', required : false, version : _flex_version)
   if prog_flex.found()
     # This uses <io.h> instead of <unistd.h>
     flex_args = ['--wincompat']

--- a/src/cps/pc_compat/pc_loader.cpp
+++ b/src/cps/pc_compat/pc_loader.cpp
@@ -92,7 +92,7 @@ namespace cps::pc_compat {
 
         std::string name = CPS_TRY(get_property("Name").and_then(get_string));
 
-        loader::LangValues compile_flags;
+        loader::LangStrings compile_flags;
         if (auto compile_flags_input = get_property("Cflags").and_then(get_string)) {
             auto compile_flags_vec = utils::split(*compile_flags_input);
             compile_flags.emplace(loader::KnownLanguages::c, compile_flags_vec);
@@ -115,7 +115,7 @@ namespace cps::pc_compat {
         components.emplace(
             name, loader::Component{.type = loader::Type::unknown,
                                     .compile_flags = compile_flags,
-                                    .includes = loader::LangValues{},
+                                    .includes = loader::LangPaths{},
                                     .definitions = loader::Defines{},
                                     .link_flags = link_flags,
                                     .link_libraries = {},

--- a/src/cps/printer.cpp
+++ b/src/cps/printer.cpp
@@ -5,11 +5,14 @@
 #include "cps/printer.hpp"
 
 #include <algorithm>
+#include <filesystem>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <tl/expected.hpp>
 
 namespace cps::printer {
+
+    namespace fs = std::filesystem;
 
     int pkgconf(const search::Result & r, const Config & conf) {
         std::vector<std::string> args{};
@@ -32,7 +35,7 @@ namespace cps::printer {
         if (conf.includes) {
             if (auto && f = r.includes.find(loader::KnownLanguages::c); f != r.includes.end() && !f->second.empty()) {
                 std::transform(f->second.begin(), f->second.end(), std::back_inserter(args),
-                               [](std::string_view s) { return fmt::format("-I{}", s); });
+                               [](const fs::path & p) { return fmt::format("-I{}", p.generic_string()); });
             }
         }
 
@@ -71,7 +74,7 @@ namespace cps::printer {
             if (auto && f = r.link_location; !f.empty()) {
                 args.reserve(args.size() + f.size());
                 std::transform(f.begin(), f.end(), std::back_inserter(args),
-                               [](std::string_view s) { return fmt::format("-l{}", s); });
+                               [](const fs::path & p) { return fmt::format("-l{}", p.generic_string()); });
             }
             if (auto && f = r.link_libraries; !f.empty()) {
                 args.reserve(args.size() + f.size());

--- a/src/cps/search.hpp
+++ b/src/cps/search.hpp
@@ -8,22 +8,25 @@
 
 #include <tl/expected.hpp>
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
 namespace cps::search {
+
+    namespace fs = std::filesystem;
 
     class Result {
       public:
         Result();
 
         std::string version;
-        loader::LangValues includes;
-        loader::LangValues compile_flags;
+        loader::LangPaths includes;
+        loader::LangStrings compile_flags;
         loader::Defines definitions;
         std::vector<std::string> link_flags;
         std::vector<std::string> link_libraries;
-        std::vector<std::string> link_location;
+        std::vector<fs::path> link_location;
     };
 
     // TODO: restrictions like versions

--- a/tests/cases/cps-config.toml
+++ b/tests/cases/cps-config.toml
@@ -82,7 +82,7 @@ expected = "-I/something -I/opt/include"
 name = "Requires version, but version not set"
 cps = "needs-version"
 args = ["flags", "--modversion", "--print-errors", "--errors-to-stdout"]
-expected = "Tried /.*/cps/multiple-components.cps, which does not specify a version or compat_version, but the user requires version 1.0"
+expected = "Tried .*/cps/multiple-components.cps, which does not specify a version or compat_version, but the user requires version 1.0"
 re = true
 returncode = 1
 

--- a/tests/cases/pkg-config-compat.toml
+++ b/tests/cases/pkg-config-compat.toml
@@ -50,7 +50,7 @@ expected = "-I/usr/local/include -I/opt/include"
 name = "Requires version, but version not set"
 cps = "needs-version"
 args = ["pkg-config", "--modversion", "--print-errors", "--errors-to-stdout"]
-expected = "Tried /.*/cps/multiple-components.cps, which does not specify a version or compat_version, but the user requires version 1.0"
+expected = "Tried .*/cps/multiple-components.cps, which does not specify a version or compat_version, but the user requires version 1.0"
 returncode = 1
 re = true
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -9,6 +9,7 @@ import asyncio
 import contextlib
 import dataclasses
 import enum
+import pathlib
 import os
 import re
 import shutil
@@ -86,6 +87,7 @@ def is_success(rt: int, case_: TestCase, out: str, expected: str) -> bool:
 
 async def test(args: Arguments, case_: TestCase) -> Result:
     prefix = args.prefix or SOURCE_DIR
+    prefix = pathlib.Path(prefix).as_posix()
 
     cmd = [args.runner] + case_['args']
     cmd.append(case_['cps'].replace('{prefix}', os.path.join(prefix, args.libdir, 'cps')))


### PR DESCRIPTION
This commit introduces initial Windows support. It mostly comes down to:

- Use ; as path separator for environment variables on Windows
- Using std::filesystem::path consistently for representing paths, avoiding use of std::string
- Use `.generic_string()` for printing any paths