### PR TITLE
Fix missing field initializers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ cpp = meson.get_compiler('cpp')
 warn_args = cpp.get_supported_arguments(
   '-Werror=shadow',
   '-Werror=implicit-fallthrough',
+  '-Werror=missing-field-initializers',
 )
 
 subdir('src')

--- a/src/cps/pc_compat/pc_loader.cpp
+++ b/src/cps/pc_compat/pc_loader.cpp
@@ -130,8 +130,10 @@ namespace cps::pc_compat {
         return loader::Package{.name = name,
                                .cps_version = std::string{loader::CPS_VERSION},
                                .components = components,
-                               // TODO: treat PREFIX in pc file specially and translate it to @prefix@
+                               .compat_version = std::nullopt,
                                .cps_path = std::nullopt,
+                               // TODO: treat PREFIX in pc file specially and translate it to @prefix@
+                               .prefix = "",
                                .filename = filename.string(),
                                .default_components = std::vector{name},
                                .platform = std::nullopt,


### PR DESCRIPTION
This adds an error for Meson, and fixing the cases in the code. CMake doesn't currently have any of the -Werror checks that Meson does, so that' been left for later